### PR TITLE
fix: eliminate data race in test helper and enforce race gate in CI

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,10 +15,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
-          go-version: 1.21
-      - uses: actions/checkout@v3
+          go-version: "1.25.x"
+      - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,18 +1,35 @@
 name: Unit tests
-on: [push, workflow_dispatch]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   unit-test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ["1.24.x", "1.25.x"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: ${{ matrix.go-version }}
 
       - name: Build
         run: go build -v ./...
 
       - name: Test
         run: go test -v ./...
+
+  race-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.x"
+
+      - name: Race test
+        run: go test -race ./...

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: Unit tests
 on: [push, pull_request, workflow_dispatch]
+permissions:
+  contents: read
 jobs:
   unit-test:
     runs-on: ubuntu-latest

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,128 @@
+# Govalin
+
+Govalin is an HTTP server framework context focused on predictable request handling and safe extension behavior. This context defines the language for quality and runtime-safety decisions that govern releases.
+
+## Language
+
+**Race-clean build**:
+A build and test run with no detected data races under race instrumentation.
+_Avoid_: mostly-safe, probably-safe
+
+**Release blocker**:
+A condition that must be resolved before a version can be shipped.
+_Avoid_: warning-only failure, non-blocking issue
+
+**Stability gate**:
+A mandatory quality check that protects runtime correctness and predictable behavior.
+_Avoid_: optional check, advisory check
+
+**Root-cause-first remediation**:
+Fix shared causes that fail broad quality gates before secondary design cleanup.
+_Avoid_: parallel mixed remediation, cosmetic-first fixes
+
+**Compatibility-preserving first fix**:
+The first remediation step keeps public helper signatures unchanged to minimize migration risk.
+_Avoid_: breaking-first cleanup, broad API rewrite in urgent fix
+
+**Scope-frozen phase one**:
+The first remediation phase addresses only the declared release-blocking fault class.
+_Avoid_: opportunistic cleanup, multi-goal phase mixing
+
+**Phase-one done criteria**:
+Phase one is complete only when race tests and default tests pass without changing the helper API.
+_Avoid_: partial green status, implicit completion standards
+
+**Policy-enforced gate**:
+A release policy is implemented as mandatory CI checks rather than team convention alone.
+_Avoid_: manual-only enforcement, optional pipeline checks
+
+**Gate-first execution order**:
+Implementation starts by restoring mandatory quality gates before non-blocking design refactors.
+_Avoid_: refactor-first execution, mixed-priority delivery
+
+**Canonical static mount URL**:
+The mount root URL is the trailing-slash form; non-slash form redirects to canonical URL.
+_Avoid_: dual canonical forms, content served on both root variants
+
+**Permanent canonical redirect**:
+Canonical URL normalization for static mount roots uses permanent redirect semantics.
+_Avoid_: provisional redirect phases, temporary canonicalization
+
+**Query-preserving canonicalization**:
+Canonical redirects normalize path shape while preserving the original query string.
+_Avoid_: query dropping, parameter mutation during URL normalization
+
+**Framework-wide redirect integrity**:
+All framework-generated redirects must preserve request query parameters unless explicitly documented otherwise.
+_Avoid_: plugin-specific redirect semantics, silent intent loss
+
+**Raw-query passthrough**:
+Redirect query preservation uses the original raw query bytes without parse/re-encode normalization.
+_Avoid_: query canonicalization side effects, reordered parameters
+
+**Pre-merge gate enforcement**:
+Mandatory stability gates run on pull requests before merge, not only after push.
+_Avoid_: post-merge-only enforcement, delayed blocker detection
+
+**Dedicated race gate job**:
+Race detection runs in a separate CI job from default unit tests for isolated quality signals.
+_Avoid_: mixed-failure jobs, opaque blocker diagnosis
+
+**Current-toolchain alignment**:
+Project and CI Go versions are actively maintained to current supported releases, not left on stale versions.
+_Avoid_: long-lived version lag, accidental legacy lock-in
+
+**Toolchain maintenance cadence**:
+Go patch levels stay at latest stable for the chosen minor, with monthly minor-review and immediate security patch adoption.
+_Avoid_: ad-hoc upgrades, undefined update responsibility
+
+**Selective race coverage**:
+Race detection runs only on the current Go baseline while compatibility matrix coverage applies to non-race tests.
+_Avoid_: race-on-all-matrix strategy, unbounded CI runtime growth
+
+**Dual-minor compatibility matrix**:
+Non-race CI tests run on current stable Go and previous minor Go versions.
+_Avoid_: single-version-only compatibility signal, oversized version matrices
+
+**Two-PR rollout**:
+Release-blocking stabilization and design refactors are delivered in separate pull requests.
+_Avoid_: mixed-risk delivery, bundled stabilization and redesign
+
+**Scope-locked PR1**:
+PR1 includes only race-helper stabilization and CI gate/toolchain updates, excluding redirect and static behavior changes.
+_Avoid_: scope bleed into routing semantics, mixed stabilization and feature behavior
+
+## Relationships
+
+- A **Race-clean build** is a required outcome of the **Stability gate**
+- A failed **Stability gate** is a **Release blocker**
+- **Root-cause-first remediation** addresses shared gate failures before localized refactors
+- **Compatibility-preserving first fix** is the default for urgent release blockers
+- **Scope-frozen phase one** limits changes to race elimination only
+- **Phase-one done criteria** require both race and default test passes with unchanged helper signatures
+- A **Policy-enforced gate** ensures race-cleanliness is continuously verified pre-merge
+- **Gate-first execution order** resolves blocking quality gates before static-route redesign
+- **Canonical static mount URL** is the trailing-slash path, with redirect from non-slash form
+- **Permanent canonical redirect** applies to static mount root normalization
+- **Query-preserving canonicalization** keeps request query parameters unchanged during static mount redirect
+- **Framework-wide redirect integrity** applies query preservation to every framework-generated redirect
+- **Raw-query passthrough** defines exact query preservation semantics for framework redirects
+- **Pre-merge gate enforcement** requires race/stability checks during pull request validation
+- **Dedicated race gate job** separates race signal from default test signal in CI
+- **Current-toolchain alignment** keeps quality gates representative of the intended modern runtime baseline
+- **Toolchain maintenance cadence** defines how “up to date” is continuously enforced
+- **Selective race coverage** keeps race checks strict on baseline without multiplying matrix cost
+- **Dual-minor compatibility matrix** provides compatibility signal on 1.25.x and 1.24.x
+- **Two-PR rollout** isolates race-gate stabilization from static-routing redesign
+- **Scope-locked PR1** constrains initial delivery to test-helper race fix and CI enforcement updates
+
+## Example dialogue
+
+> **Dev:** "Regular tests pass, but race tests fail. Can we still release?"
+> **Maintainer:** "No. A failed stability gate is a release blocker, and race-clean is required."
+
+## Flagged ambiguities
+
+- "tests pass" was used to mean only default test execution and also all quality gates; resolved: release readiness requires passing mandatory stability gates, including race checks.
+- CI currently runs default tests but does not run race tests; resolved: race-clean will be enforced in CI as a mandatory gate.
+- Existing HTTP->HTTPS plugin redirect currently uses only URL path and drops query parameters; resolved: query-preserving behavior applies framework-wide and this behavior must be aligned.

--- a/internal/govalintesting/testing.go
+++ b/internal/govalintesting/testing.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pkkummermo/govalin"
 )
 
-const generalStartupTimeoutInMS = 1
+const generalStartupTimeoutInMS = 50
 
 type (
 	TestFunc func(app *govalin.App) *govalin.App
@@ -258,9 +258,9 @@ func HTTPTestUtil(serverF TestFunc, testFunc ExecFunc) {
 	server := serverF(testInstance)
 
 	go func() {
-		err = server.Start(port)
-		if err != nil {
-			slog.Error(fmt.Sprintf("Failed to start test server. %v", err))
+		startErr := server.Start(port)
+		if startErr != nil {
+			slog.Error(fmt.Sprintf("Failed to start test server. %v", startErr))
 			os.Exit(1)
 		}
 	}()
@@ -284,9 +284,9 @@ func HTTPTestUtil(serverF TestFunc, testFunc ExecFunc) {
 		},
 	), Host: fmt.Sprintf("http://localhost:%d", port)})
 
-	err = server.Shutdown()
-	if err != nil {
-		slog.Error(fmt.Sprintf("Failed to shutdown test server. %v", err))
+	shutdownErr := server.Shutdown()
+	if shutdownErr != nil {
+		slog.Error(fmt.Sprintf("Failed to shutdown test server. %v", shutdownErr))
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## Summary

- Remove shared `err` variable written across goroutines in `HTTPTestUtil` (start goroutine and shutdown caller both wrote to the same `err`)
- Increase `generalStartupTimeoutInMS` from 1ms to 50ms to prevent flaky startup-timeout failures under race instrumentation
- Add `pull_request` trigger and Go 1.24.x/1.25.x matrix to unit-test job
- Add dedicated `race-test` job running `go test -race` on Go 1.25.x only
- Align CI Go version and action versions to current baseline (1.25.x, actions/checkout@v4, actions/setup-go@v5)
- Add CONTEXT.md capturing agreed domain language and quality policies

## Verification

- `go test ./...` passes
- `go test -race ./...` passes