### PR TITLE
Use rune count for MinLength/MaxLength validation

### DIFF
--- a/internal/validation/validator.go
+++ b/internal/validation/validator.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 )
 
 // Rule represents a single validation rule.
@@ -66,7 +67,7 @@ func Required() Rule[string] {
 // MinLength validates minimum string length.
 func MinLength(minimum int) Rule[string] {
 	return func(value string, fieldName string) *Error {
-		if len(value) < minimum {
+		if utf8.RuneCountInString(value) < minimum {
 			return NewError(NewErrorResponse(
 				http.StatusBadRequest,
 				NewParameterErrorDetail(fieldName, fmt.Sprintf("Must be at least %d characters long", minimum)),
@@ -79,7 +80,7 @@ func MinLength(minimum int) Rule[string] {
 // MaxLength validates maximum string length.
 func MaxLength(maximum int) Rule[string] {
 	return func(value string, fieldName string) *Error {
-		if len(value) > maximum {
+		if utf8.RuneCountInString(value) > maximum {
 			return NewError(NewErrorResponse(
 				http.StatusBadRequest,
 				NewParameterErrorDetail(fieldName, fmt.Sprintf("Must be at most %d characters long", maximum)),

--- a/internal/validation/validator_test.go
+++ b/internal/validation/validator_test.go
@@ -73,6 +73,15 @@ func TestMinLength(t *testing.T) {
 		{"below minimum", "ab", 3, true},
 		{"empty string", "", 3, true},
 		{"zero minimum", "a", 0, false},
+		// Multi-byte characters must be counted as runes, not bytes.
+		// "café" is 4 runes but 5 bytes, so it must satisfy a minimum of 4.
+		{"multibyte meets minimum by runes", "café", 4, false},
+		// 4 runes is below a minimum of 5, even though len() reports 5 bytes.
+		{"multibyte below minimum by runes", "café", 5, true},
+		// "日本" is 2 runes but 6 bytes; it must fail a minimum of 3.
+		{"cjk below minimum by runes", "日本", 3, true},
+		// "👍" is 1 rune but 4 bytes; it must fail a minimum of 2.
+		{"emoji below minimum by runes", "👍", 2, true},
 	}
 
 	for _, tt := range tests {
@@ -104,6 +113,15 @@ func TestMaxLength(t *testing.T) {
 		{"empty string", "", 3, false},
 		{"zero maximum", "", 0, false},
 		{"zero maximum with content", "a", 0, true},
+		// Multi-byte characters must be counted as runes, not bytes.
+		// "café" is 4 runes but 5 bytes, so it must satisfy a maximum of 4.
+		{"multibyte at maximum by runes", "café", 4, false},
+		// "日本語" is 3 runes but 9 bytes; it must satisfy a maximum of 3.
+		{"cjk at maximum by runes", "日本語", 3, false},
+		// "👍👍" is 2 runes but 8 bytes; it must satisfy a maximum of 2.
+		{"emoji within maximum by runes", "👍👍", 2, false},
+		// 5 runes exceeds a maximum of 4, even though that is allowed by bytes.
+		{"multibyte above maximum by runes", "héllo", 4, true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

`MinLength` and `MaxLength` in `internal/validation/validator.go` used `len()` on the string, which counts **bytes**, not characters. Non-ASCII input — accented characters, emoji, CJK, etc. — was over-counted against the length limits (e.g. `"café"` counted as 5, `"👍"` as 4).

Switched both rules to `utf8.RuneCountInString` so limits reflect characters (runes).

## Notes

`RuneCountInString` counts Unicode code points, not grapheme clusters — combining sequences and multi-rune emoji (e.g. flag emoji) still count as more than one. That's the standard tradeoff and appropriate for length validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)