### PR TITLE
Use rune count for public StringValidator MinLength/MaxLength

### DIFF
--- a/validation.go
+++ b/validation.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/pkkummermo/govalin/internal/validation"
 )
@@ -58,7 +59,7 @@ func (v *StringValidator) Required() *StringValidator {
 // MinLength adds a minimum length validation rule.
 func (v *StringValidator) MinLength(minimum int) *StringValidator {
 	v.rules = append(v.rules, func(value, fieldName string) error {
-		if len(value) < minimum {
+		if utf8.RuneCountInString(value) < minimum {
 			return validation.NewError(validation.NewErrorResponse(
 				http.StatusBadRequest,
 				validation.NewParameterErrorDetail(fieldName, fmt.Sprintf("Must be at least %d characters long", minimum)),
@@ -72,7 +73,7 @@ func (v *StringValidator) MinLength(minimum int) *StringValidator {
 // MaxLength adds a maximum length validation rule.
 func (v *StringValidator) MaxLength(maximum int) *StringValidator {
 	v.rules = append(v.rules, func(value, fieldName string) error {
-		if len(value) > maximum {
+		if utf8.RuneCountInString(value) > maximum {
 			return validation.NewError(validation.NewErrorResponse(
 				http.StatusBadRequest,
 				validation.NewParameterErrorDetail(fieldName, fmt.Sprintf("Must be at most %d characters long", maximum)),

--- a/validation_test.go
+++ b/validation_test.go
@@ -54,6 +54,53 @@ func TestValidatedQueryParam(t *testing.T) {
 	})
 }
 
+// TestValidatedQueryParamRuneLength verifies that MinLength/MaxLength on the
+// public StringValidator count runes rather than bytes, so multi-byte input
+// (accented characters, emoji) is measured by character count.
+func TestValidatedQueryParamRuneLength(t *testing.T) {
+	govalintesting.HTTPTestUtil(func(app *govalin.App) *govalin.App {
+		// Requires at least 5 characters.
+		app.Post("/validate-rune-min", func(call *govalin.Call) {
+			name, err := call.ValidatedQueryParam("name").MinLength(5).Get()
+			if err != nil {
+				call.Error(err)
+				return
+			}
+			call.JSON(map[string]string{"message": "Valid name", "name": name})
+		})
+
+		// Allows at most 4 characters.
+		app.Post("/validate-rune-max", func(call *govalin.Call) {
+			name, err := call.ValidatedQueryParam("name").MaxLength(4).Get()
+			if err != nil {
+				call.Error(err)
+				return
+			}
+			call.JSON(map[string]string{"message": "Valid name", "name": name})
+		})
+
+		return app
+	}, func(http govalintesting.GovalinHTTP) {
+		// "café" is 4 runes but 5 bytes. It must fail a minimum of 5 runes,
+		// even though a byte-based check (len == 5) would have passed it.
+		response := http.Post("/validate-rune-min?name=caf%C3%A9", map[string]string{})
+		assert.Contains(t, response, "Must be at least 5 characters long")
+
+		// "café" (4 runes / 5 bytes) must satisfy a maximum of 4 runes,
+		// even though a byte-based check (len == 5) would have rejected it.
+		response = http.Post("/validate-rune-max?name=caf%C3%A9", map[string]string{})
+		assert.Contains(t, response, "Valid name")
+
+		// "👍👍" is 2 runes but 8 bytes; it must satisfy a maximum of 4 runes.
+		response = http.Post("/validate-rune-max?name=%F0%9F%91%8D%F0%9F%91%8D", map[string]string{})
+		assert.Contains(t, response, "Valid name")
+
+		// "héllo" is 5 runes; it must exceed a maximum of 4 runes.
+		response = http.Post("/validate-rune-max?name=h%C3%A9llo", map[string]string{})
+		assert.Contains(t, response, "Must be at most 4 characters long")
+	})
+}
+
 func TestValidatedPathParam(t *testing.T) {
 	govalintesting.HTTPTestUtil(func(app *govalin.App) *govalin.App {
 		app.Post("/validate-path/{username}", func(call *govalin.Call) {


### PR DESCRIPTION
## Summary

Follow-up to #55. That PR fixed the **internal** validation rules to count runes instead of bytes, but the **public** `StringValidator` wrapper in `validation.go` had the same byte-vs-character bug and was missed (the third commit landed after #55 was already merged).

This applies the same `utf8.RuneCountInString` fix to `StringValidator.MinLength` / `MaxLength`, so multi-byte input (accented characters, emoji, CJK) is measured by character count rather than byte length.

## Tests

Adds `TestValidatedQueryParamRuneLength`, an HTTP-level test exercising the public validator through query params:
- `café` (4 runes / 5 bytes) fails `MinLength(5)` and passes `MaxLength(4)` — both would behave wrong under the old `len()`
- `👍👍` (2 runes / 8 bytes) passes `MaxLength(4)`
- `héllo` (5 runes) fails `MaxLength(4)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)