### PR TITLE
docs: capture transform-aware validation pipeline decision

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -92,6 +92,18 @@ _Avoid_: mixed-risk delivery, bundled stabilization and redesign
 PR1 includes only race-helper stabilization and CI gate/toolchain updates, excluding redirect and static behavior changes.
 _Avoid_: scope bleed into routing semantics, mixed stabilization and feature behavior
 
+**Validation rule**:
+A check applied to an input that asserts a condition and leaves the value unchanged; it either passes or yields a validation error.
+_Avoid_: value-mutating check, silent correction
+
+**Transform step**:
+A step in an input-handling chain that normalizes the value (such as trimming surrounding whitespace) and always succeeds, never producing a validation error.
+_Avoid_: erroring normalizer, validation-as-transform
+
+**Chain order significance**:
+Rules and transforms apply in written order; a transform only affects checks placed after it in the chain.
+_Avoid_: implicit reordering, position-independent transforms
+
 ## Relationships
 
 - A **Race-clean build** is a required outcome of the **Stability gate**
@@ -115,6 +127,8 @@ _Avoid_: scope bleed into routing semantics, mixed stabilization and feature beh
 - **Dual-minor compatibility matrix** provides compatibility signal on 1.25.x and 1.24.x
 - **Two-PR rollout** isolates race-gate stabilization from static-routing redesign
 - **Scope-locked PR1** constrains initial delivery to test-helper race fix and CI enforcement updates
+- A **Validation rule** asserts on an input without changing it; a **Transform step** changes the value and never fails
+- **Chain order significance** means a **Transform step** only reaches a **Validation rule** placed after it
 
 ## Example dialogue
 

--- a/docs/adr/0001-transform-aware-validation-pipeline.md
+++ b/docs/adr/0001-transform-aware-validation-pipeline.md
@@ -1,0 +1,36 @@
+# Transform-aware string validation pipeline
+
+## Status
+
+accepted
+
+## Context and decision
+
+The curryable `StringValidator` accumulated rules as `func(string, string) error` and `Get()`
+returned the original captured value unchanged — the pipeline could assert on a value but never
+change it. To support normalizing transforms (the first being `Trim()`, which removes surrounding
+whitespace), we changed the internal rule type to `func(string, string) (string, error)` so each
+step can return a possibly-modified value alongside an error. `Get()` threads the value through the
+chain in order and returns the final transformed result. Public method signatures are unchanged;
+only the unexported `rules` field type changed.
+
+This makes the chain position-sensitive: a transform only affects checks placed after it
+(`Trim().MinLength(3)` measures the trimmed value; reversing them does not). Transform steps never
+return an error.
+
+## Considered options
+
+- **Transform-aware pipeline (chosen)** — rules return `(string, error)`. Keeps the lazy/curried
+  contract, makes ordering meaningful and honest, generalizes to future transforms.
+- **Eager mutation** — `Trim()` mutates the captured value immediately when called. Rejected: breaks
+  the lazy contract and makes a step's written position meaningless.
+- **Separate transforms slice** — keep rules error-only, add a parallel transform list applied first.
+  Rejected: loses interleaved ordering between transforms and validations.
+
+## Consequences
+
+- `IntValidator` and `BodyValidator` keep the older error-only shape; the sibling validators now have
+  different internal pipeline shapes. This is deliberate (YAGNI — no numeric/body transform exists yet)
+  and invisible to users since the field is unexported.
+- Body-field trimming is deferred: it would require writing the trimmed value back into the caller's
+  struct via reflection, which is a separate semantic decision.


### PR DESCRIPTION
Documents the design decision behind the upcoming `StringValidator.Trim()` feature (#60), with no code changes.

## What's here

- **CONTEXT.md** — new glossary terms and relationships:
  - **Validation rule** — asserts a condition, leaves the value unchanged, may error.
  - **Transform step** — normalizes the value (e.g. trimming whitespace), always succeeds.
  - **Chain order significance** — rules and transforms apply in written order; a transform only affects checks placed after it.
- **docs/adr/0001-transform-aware-validation-pipeline.md** — records the decision to change the internal `StringValidator` rule type from `func(string, string) error` to `func(string, string) (string, error)` so steps can transform the value, the rejected alternatives (eager mutation, separate transforms slice), and the consequences.

## Why now

The `Trim()` implementation (#60) depends on this pipeline shape. Landing the rationale first keeps the feature PR focused on code.

Related: #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)