### PR TITLE
fix(server): flush buffered status at end of lifecycle

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -104,6 +104,18 @@ _Avoid_: erroring normalizer, validation-as-transform
 Rules and transforms apply in written order; a transform only affects checks placed after it in the chain.
 _Avoid_: implicit reordering, position-independent transforms
 
+**Buffered status**:
+A status code set via `Status()` that is held on the call and not yet committed to the response writer.
+_Avoid_: eager status write, status sent immediately on set
+
+**Status flush**:
+Committing the buffered status to the writer. Happens on the first body write (JSON/Text/HTML/Redirect) or, when no body is written, exactly once at the end of the request lifecycle.
+_Avoid_: implicit 200 on unflushed status, multiple status writes
+
+**Lifecycle bypass**:
+A request whose handler takes ownership of the raw writer (HTTPServe); govalin performs no status flush or response finalization for it.
+_Avoid_: framework-managed finalization on raw handlers, double-writing a bypassed response
+
 ## Relationships
 
 - A **Race-clean build** is a required outcome of the **Stability gate**
@@ -129,6 +141,9 @@ _Avoid_: implicit reordering, position-independent transforms
 - **Scope-locked PR1** constrains initial delivery to test-helper race fix and CI enforcement updates
 - A **Validation rule** asserts on an input without changing it; a **Transform step** changes the value and never fails
 - **Chain order significance** means a **Transform step** only reaches a **Validation rule** placed after it
+- A **Buffered status** becomes visible to the client only after a **Status flush**
+- A **Status flush** happens at most once per request: on first body write, or otherwise at end of lifecycle
+- **Lifecycle bypass** suppresses **Status flush** — the handler owns response finalization
 
 ## Example dialogue
 

--- a/call.go
+++ b/call.go
@@ -459,10 +459,13 @@ func (call *Call) HeaderOrDefault(key string, def string) string {
 	return value
 }
 
-// Set HTTP status that will be used on JSON/Text/HTML calls
+// Set HTTP status that will be used on the response
 //
-// If the status has already been set, a warning will be printed. The status will not be
-// written to the response until a JSON/Text/HTML-call is made.
+// The status is buffered on the call and committed to the response on the first
+// body write (JSON/Text/HTML/Redirect) or, if no body is written, once at the
+// end of the request lifecycle. Setting a status alone is therefore enough to
+// send it. Requests that take over the raw writer (HTTPServe) are never flushed
+// by the framework.
 func (call *Call) Status(statusCode ...int) int {
 	if len(statusCode) > 0 {
 		call.status = statusCode[0]

--- a/call_test.go
+++ b/call_test.go
@@ -176,6 +176,45 @@ func TestCookies(t *testing.T) {
 			"govalin=govalin",
 			"Should set correct header when setting cookie",
 		)
+		assert.Equal(
+			t,
+			204,
+			response.StatusCode,
+			"Should send the status set by the handler even with no body",
+		)
+	})
+}
+
+func TestStatusOnlyResponse(t *testing.T) {
+	govalintesting.HTTPTestUtil(func(app *govalin.App) *govalin.App {
+		app.Get("/nobody", func(call *govalin.Call) {
+			call.Status(204)
+		})
+		app.Before("/guarded", func(call *govalin.Call) bool {
+			call.Status(401)
+			return false
+		})
+		app.Get("/guarded", func(call *govalin.Call) {
+			call.Text("should never run")
+		})
+
+		return app
+	}, func(http govalintesting.GovalinHTTP) {
+		nobodyResponse := http.GetResponse("/nobody")
+		assert.Equal(
+			t,
+			204,
+			nobodyResponse.StatusCode,
+			"A handler that sets a status but writes no body should send that status",
+		)
+
+		guardedResponse := http.GetResponse("/guarded")
+		assert.Equal(
+			t,
+			401,
+			guardedResponse.StatusCode,
+			"A before handler that short-circuits with a status but no body should send that status",
+		)
 	})
 }
 

--- a/docs/adr/0002-end-of-lifecycle-status-flush.md
+++ b/docs/adr/0002-end-of-lifecycle-status-flush.md
@@ -1,0 +1,47 @@
+# End-of-lifecycle status flush
+
+## Status
+
+accepted
+
+## Context and decision
+
+`Status()` sets a **buffered status** on the call; it is committed to the writer only by a
+**status flush**. Until this decision the only flush sites were the body-writing methods
+(`JSON`/`Text`/`HTML`/`Redirect`) via `sendStatusOrDefault()`. A handler that wanted to reply
+"status only, no body" — e.g. `call.Status(204); return` — therefore never flushed: `net/http`
+finished the request with an implicit `200 OK`, discarding the intended status. The same silent-200
+bug applied to a `Before` handler that short-circuited with a status but no body (`call.Status(401);
+return false`).
+
+We make the buffered status flush at the end of the request lifecycle on every non-bypass exit path.
+A deferred closure in `rootHandlerFunc` calls `sendStatusOrDefault()` (idempotent — guarded by
+`statusWritten`), so a status set by a handler or a short-circuiting before handler is always
+committed. After this change, setting a status is sufficient to send it; no new public API is needed.
+
+The bypass guard is evaluated when the defer **runs**, not when it is registered. `bypassLifecycle`
+is set to `true` inside the handler (`HTTPServe`), which executes after the defer is registered, so a
+guard snapshotted at registration time would wrongly flush over a raw response the handler already
+wrote. The closure reads `call.bypassLifecycle` at run time and skips the flush for **lifecycle
+bypass** requests, leaving response finalization entirely to the handler.
+
+## Considered options
+
+- **End-of-lifecycle auto-flush (chosen)** — buffered status is committed once at the end of every
+  non-bypass path. Makes `Status()` honest, kills the silent-200 class for both no-body handlers and
+  before-handler short-circuits, and adds no public surface.
+- **Explicit `Send()`/`SendStatus()` method** — handler must call it to flush a no-body status.
+  Rejected: a status set without the follow-up call still silently becomes 200, preserving the exact
+  trap and adding API the framework can forget to require.
+- **Flush only on the normal-completion path** — explicit flush at the end of `rootHandlerFunc`.
+  Rejected: leaves the before-handler short-circuit path emitting a silent 200 for status-only
+  rejects.
+
+## Consequences
+
+- A request that sets a status and writes no body now sends that status; `Status()`'s doc contract
+  is updated to say the status is flushed on a body write **or** at end of lifecycle.
+- `HTTPServe` (lifecycle bypass) is untouched: the run-time guard means govalin never writes a status
+  for a request whose handler owns the raw writer.
+- The defer registers after the access-log defer, so LIFO ordering flushes the status before the
+  access log records it — the log reports the status actually sent.

--- a/server.go
+++ b/server.go
@@ -395,6 +395,21 @@ func (server *App) rootHandlerFunc(w http.ResponseWriter, req *http.Request) {
 		}()
 	}
 
+	// Flush the buffered status on every non-bypass exit path so a handler (or a
+	// short-circuiting before handler) that sets a status but writes no body
+	// still sends that status instead of an implicit 200 OK. The bypass check is
+	// evaluated when the defer runs, not when it is registered, because
+	// HTTPServe sets bypassLifecycle inside the handler which runs after this
+	// point; a snapshot here would wrongly flush over a raw response. Registered
+	// after the access-log defer so LIFO ordering flushes before the log records
+	// the status. sendStatusOrDefault is idempotent, so an already-written
+	// response is left untouched.
+	defer func() {
+		if !call.bypassLifecycle {
+			call.sendStatusOrDefault()
+		}
+	}()
+
 	// Look for before handlers
 	if !server.matchBeforeHandlers(&call) || call.bypassLifecycle {
 		return


### PR DESCRIPTION
## Problem

`Status()` only *buffers* a status code — it is committed to the response writer solely by the body methods (`JSON`/`Text`/`HTML`/`Redirect`). So a handler that replies "status only, no body":

```go
call.Status(204)
return
```

never flushes, and `net/http` finishes the request with an implicit **200 OK**, discarding the intended status. The same silent-200 bug applies to a `Before` handler that short-circuits with a status but no body (`call.Status(401); return false`).

The existing cookie test set `204` but only asserted the `Set-Cookie` header, so it never caught this.

## Fix

Flush the buffered status via a deferred `sendStatusOrDefault()` on every non-bypass exit path of `rootHandlerFunc`. Key subtlety: the bypass guard is evaluated **when the defer runs**, not when it is registered — `HTTPServe` sets `bypassLifecycle` inside the handler, which runs after the defer is registered, so a snapshot would wrongly flush over a raw response the handler already wrote. Registered after the access-log defer so LIFO ordering flushes before the log records the status. `sendStatusOrDefault()` is idempotent, so already-written responses are untouched.

Chose end-of-lifecycle auto-flush over an explicit `Send()`/`SendStatus()` method: a status set without the follow-up call would still silently become 200, preserving the exact trap. See [ADR 0002](docs/adr/0002-end-of-lifecycle-status-flush.md).

## Changes

- **server.go** — deferred status flush with run-time bypass guard
- **call.go** — updated `Status()` doc comment to the new contract
- **call_test.go** — tightened the cookie test to assert `204`; added `TestStatusOnlyResponse` covering the no-body handler and the before-handler short-circuit
- **CONTEXT.md** — glossary terms: *Buffered status*, *Status flush*, *Lifecycle bypass*
- **docs/adr/0002** — records the decision and rejected alternatives

## Verification

- `go build ./...` — clean
- `go test -race ./...` — all packages pass, race-clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)