### PR TITLE
feat(server): expose bound port via App.Port()

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -116,6 +116,22 @@ _Avoid_: implicit 200 on unflushed status, multiple status writes
 A request whose handler takes ownership of the raw writer (HTTPServe); govalin performs no status flush or response finalization for it.
 _Avoid_: framework-managed finalization on raw handlers, double-writing a bypassed response
 
+**Bound port**:
+The port the server is actually listening on, read from the live listener (`listener.Addr()`), as opposed to the configured port. When the configured port is `0` the OS assigns a free port, so only the bound port is authoritative. Exposed to plugins via `App.Port()`.
+_Avoid_: configured-port-as-truth, advertising a port the server is not listening on
+
+**Service advertisement**:
+Publishing the server on the local network as a full DNS-SD service instance (instance name + service type in the `.local` domain, with SRV/TXT/PTR records) over mDNS — not merely a resolvable hostname. A registered service is both resolvable and browsable by standard discovery tooling.
+_Avoid_: hostname-only A-record publishing, "discovery means just resolving myapp.local"
+
+**Plugin complexity boundary**:
+GOVALIN core stays simple, lean, and easy to configure; any added complexity or heavier dependency (including CGo) belongs in a plugin, never core, because plugins are opt-in and not required for the framework to work. Core's dependency cost is paid by every user; a plugin's is paid only by those who import it.
+_Avoid_: feature creep into core, mandatory-by-default dependencies, CGo in the core import graph
+
+**Actionable runtime warning**:
+A non-fatal log emitted when an auxiliary runtime operation fails (e.g. mDNS registration/broadcast) must state what went wrong and what the user can do to fix it — not merely that an operation failed. Misconfiguration, by contrast, is caught early and is fatal.
+_Avoid_: "failed to start/configure" with no cause or remedy, silent runtime degradation
+
 ## Relationships
 
 - A **Race-clean build** is a required outcome of the **Stability gate**

--- a/docs/adr/0003-mdns-service-advertisement-plugin.md
+++ b/docs/adr/0003-mdns-service-advertisement-plugin.md
@@ -1,0 +1,60 @@
+# mDNS service advertisement as an opt-in plugin
+
+## Status
+
+accepted
+
+## Context and decision
+
+GOVALIN apps should be able to expose themselves on the local network for zero-config discovery
+(open `myapp.local` in a browser, show up in Bonjour/`avahi-browse` lists) without the developer
+hand-wiring any of it. We add this as **mDNS service advertisement only** — publishing the running
+server over multicast DNS. Service *discovery/browsing* (acting as a client to find other services)
+and any auto-update or binary-distribution machinery are explicitly **out of scope**: GOVALIN is a
+lean HTTP framework, and discovery enables a distribution story without GOVALIN owning it.
+
+The feature ships as an **opt-in plugin** (`plugins/mdns`), not core config. mDNS needs a real
+dependency (`brutella/dnssd`, which pulls `miekg/dns`); per the **plugin complexity boundary**, that
+cost must be paid only by users who import it, never by every core user. The existing plugin
+lifecycle is sufficient — the plugin advertises in `Apply` (the listener is already bound by then)
+and withdraws (goodbye packets) via an `onServerShutdown` hook registered in `OnInit`. No new
+`Plugin` interface method is needed.
+
+The plugin advertises a **full DNS-SD `_http._tcp` service** (resolvable *and* browsable), not a bare
+hostname — the service registration is the superset that delivers both. Zero-config defaults:
+instance name = executable base name, service type = `_http._tcp`, hostname = `<os-hostname>.local`,
+all multicast-capable interfaces, TXT = `{path:/}`. Every default is overridable. Name collisions on
+the network are resolved by DNS-SD probing (`(2)`/`(3)` suffixing) provided by the library — a key
+reason for the library choice.
+
+One enabling **core** change is required and ships as its **own separate PR ahead of the plugin**: a
+new `App.Port() uint16` accessor sourced from `listener.Addr()`. A plugin currently cannot read the
+bound port (the field is unexported, no accessor), and `Start()` discards the real port when the
+configured port is `0` (OS-assigned). Sourcing from the live listener fixes that discard bug and is
+generally useful beyond mDNS.
+
+## Considered options
+
+- **Plugin (chosen)** vs **core `Config.EnableMDNS()`** — core would drag the mDNS/`miekg/dns`
+  dependency into every GOVALIN build, violating the lean-core principle. Plugin isolates it.
+- **brutella/dnssd (chosen)** vs **grandcat/zeroconf** vs **hashicorp/mdns** — brutella is the only
+  pure-Go option that implements probing-based conflict resolution and goodbye packets and is still
+  maintained. grandcat's conflict resolution is incomplete (undercutting the chosen rename-on-collision
+  behavior); hashicorp/mdns is effectively unmaintained with weak IPv6.
+- **Full DNS-SD service (chosen)** vs **hostname-only A record** — hostname-only resolves
+  `myapp.local` but stays invisible to discovery tooling, defeating the purpose.
+
+## Consequences
+
+- **Failure asymmetry, deliberate.** Misconfiguration (bad service type, oversized TXT) is caught in
+  `OnInit` and is **fatal**, consistent with how the cors plugin fatals on bad config. Runtime
+  registration/broadcast failure (no multicast route, blocked UDP 5353, container without host
+  networking) is **non-fatal** — the HTTP server is healthy and keeps serving. A future reader seeing
+  mDNS failure merely warn while a duplicate-route registration calls `os.Exit(1)` should know this
+  split is intentional: config errors fatal, runtime-environment errors warn.
+- Runtime warnings must be **actionable** — state the cause and the fix (e.g. the Docker
+  host-networking limitation), never just "failed to start mDNS".
+- Multicast typically does not cross the default Docker bridge; this is documented and surfaced as an
+  actionable warning rather than worked around in code.
+- `App.Port()` becomes public API (additive, harder to reverse) and reads the listener rather than the
+  configured value — intentional, to report the truly-bound port.

--- a/server.go
+++ b/server.go
@@ -241,6 +241,14 @@ func (server *App) Start(port ...uint16) error {
 		return listenerErr
 	}
 
+	// Read the port back from the listener so the bound port is authoritative.
+	// When the configured port is 0 the OS assigns a free port, which is only
+	// reflected in listener.Addr(); without this, server.port would stay 0 and
+	// Port() would report a port the server is not listening on.
+	if tcpAddr, ok := listener.Addr().(*net.TCPAddr); ok {
+		server.port = uint16(tcpAddr.Port)
+	}
+
 	// Initialize all plugins
 	for _, plugin := range server.config.server.plugins {
 		slog.Debug(fmt.Sprintf("Plugins: Running Apply for '%s'", plugin.Name()))
@@ -271,6 +279,16 @@ func (server *App) Start(port ...uint16) error {
 	}
 
 	return nil
+}
+
+// Port returns the port the server is bound to.
+//
+// After Start, this is the port the listener is actually bound to, read from
+// the live listener — so when the server is started on port 0 (OS-assigned
+// ephemeral port) this returns the real assigned port, not 0. Before Start is
+// called it returns the zero value.
+func (server *App) Port() uint16 {
+	return server.port
 }
 
 // Shutdown the govalin server

--- a/server_test.go
+++ b/server_test.go
@@ -1,12 +1,70 @@
 package govalin_test
 
 import (
+	"fmt"
+	"net"
+	"net/url"
 	"testing"
+	"time"
 
 	"github.com/pkkummermo/govalin"
 	"github.com/pkkummermo/govalin/internal/govalintesting"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestPortReflectsBoundPort(t *testing.T) {
+	var app *govalin.App
+	govalintesting.HTTPTestUtil(func(testApp *govalin.App) *govalin.App {
+		app = testApp
+		return testApp
+	}, func(http govalintesting.GovalinHTTP) {
+		hostURL, err := url.Parse(http.Host)
+		require.NoError(t, err)
+
+		assert.Equal(
+			t,
+			hostURL.Port(),
+			fmt.Sprintf("%d", app.Port()),
+			"Port() should report the port the server is bound to",
+		)
+	})
+}
+
+func TestPortReturnsOSAssignedPortWhenStartedOnZero(t *testing.T) {
+	// HTTPTestUtil always binds a pre-resolved concrete port and never exercises
+	// the OS-assigned (Start(0)) path this test covers, so this case uses a
+	// minimal bespoke start/shutdown harness.
+	startup := make(chan bool, 1)
+	app := govalin.New(func(config *govalin.Config) {
+		config.EnableAccessLog(false)
+		config.EnableStartupLog(false)
+		config.Events(func(events *govalin.ServerEvents) {
+			events.AddOnServerStartup(func() { startup <- true })
+		})
+	})
+
+	go func() {
+		if err := app.Start(0); err != nil {
+			t.Errorf("failed to start server on port 0: %v", err)
+		}
+	}()
+
+	select {
+	case <-startup:
+	case <-time.After(time.Second):
+		t.Fatal("server startup timed out")
+	}
+	defer func() { _ = app.Shutdown() }()
+
+	boundPort := app.Port()
+	assert.NotZero(t, boundPort, "Port() should return the real OS-assigned port, not 0")
+
+	// The reported port must be the one the server actually listens on.
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", boundPort), time.Second)
+	require.NoError(t, err, "server should be reachable on the port reported by Port()")
+	_ = conn.Close()
+}
 
 func TestGet(t *testing.T) {
 	govalintesting.HTTPTestUtil(func(app *govalin.App) *govalin.App {


### PR DESCRIPTION
Closes #64.

## What

Adds a public `App.Port() uint16` accessor and sources the bound port from `listener.Addr()` after `Start`.

When the server is started on port `0`, the OS assigns an ephemeral port that was previously discarded (`server.port` stayed `0`). `Port()` now reports the port the server is **actually** listening on. This is the enabling core change for the upcoming `plugins/mdns` advertisement plugin (#65), but is generally useful on its own.

See [ADR 0003](docs/adr/0003-mdns-service-advertisement-plugin.md) for the surrounding design.

## Changes

- `App.Port()` accessor, documented (real bound port after `Start`; zero value before).
- Bound port read from `listener.Addr()` so it is authoritative even for OS-assigned ports.
- Tests: explicit-port echo, and ephemeral-port (`0`) returning a non-zero port that is reachable.

## Notes

- The first commit (`docs:`) carries the shared mDNS design (ADR 0003 + glossary terms). It can be split into its own PR if preferred — the code commit stands alone.
- Full suite passes under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)