### PR TITLE
feat(plugins): log mDNS advertisement target on successful setup

### DIFF
--- a/plugins/mdns/mdns.go
+++ b/plugins/mdns/mdns.go
@@ -135,6 +135,8 @@ func (config *Config) Apply(app *govalin.App) {
 		return
 	}
 
+	slog.Info(config.advertisementMessage(port))
+
 	ctx, cancel := context.WithCancel(context.Background())
 	config.cancel = cancel
 	config.done = make(chan struct{})
@@ -208,6 +210,17 @@ func (config *Config) checkConfiguration() {
 		slog.Error(fmt.Sprintf("mDNS plugin: %v", err))
 		os.Exit(1)
 	}
+}
+
+// advertisementMessage describes where the service is advertised and what it
+// points to, for the success log line emitted once setup succeeds.
+func (config *Config) advertisementMessage(port uint16) string {
+	instance := config.instanceName + "." + config.serviceType + "." + localDomain
+	host := normalizeHost(config.hostname) + "." + localDomain
+
+	return fmt.Sprintf("mDNS plugin: advertising %q → %s:%d on the local network "+
+		"(browse with \"dns-sd -B %s\" or \"avahi-browse -a\")",
+		instance, host, port, config.serviceType)
 }
 
 func (config *Config) warnRuntimeFailure(err error) {

--- a/plugins/mdns/mdns_test.go
+++ b/plugins/mdns/mdns_test.go
@@ -79,6 +79,18 @@ func TestValidateText(t *testing.T) {
 	assert.Error(t, validateText(map[string]string{"k": overLimit}))
 }
 
+func TestAdvertisementMessage(t *testing.T) {
+	msg := New().
+		InstanceName("govalin-app").
+		ServiceType("_http._tcp").
+		Hostname("myhost.local").
+		advertisementMessage(7654)
+
+	assert.Contains(t, msg, "govalin-app._http._tcp.local")
+	assert.Contains(t, msg, "myhost.local:7654")
+	assert.Contains(t, msg, "dns-sd -B _http._tcp")
+}
+
 func TestNormalizeHost(t *testing.T) {
 	assert.Equal(t, "myhost", normalizeHost("myhost"))
 	assert.Equal(t, "myhost", normalizeHost("myhost.local"))


### PR DESCRIPTION
## What

Adds an info log line when the `plugins/mdns` responder is set up successfully, so users can see where mDNS is advertising and what it points to. Previously a successful setup was silent — only failures were logged.

Example output:

```
INFO mDNS plugin: advertising "govalin-check._http._tcp.local" → Pers-Air.localdomain.local:7655 on the local network (browse with "dns-sd -B _http._tcp" or "avahi-browse -a")
```

## Where it logs

The line is emitted in `Apply` right after `responder.Add()` succeeds (the multicast sockets are open by then via `NewResponder()`). Genuine post-setup failures remain rare and still hit the existing non-fatal warning path. The message is built by a pure `advertisementMessage` helper from the configured instance name, service type, hostname, and bound `App.Port()`.

## Tests

- Unit test asserting the message contains the service instance, `host:port`, and browse hint.
- Verified live: ran a small app and confirmed the line appears on startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)