### PR TITLE
fix(static): stop double-writing the response header on asset requests

### DIFF
--- a/serve-http_test.go
+++ b/serve-http_test.go
@@ -12,8 +12,10 @@ import (
 func TestServeHTTP(t *testing.T) {
 	govalintesting.HTTPTestUtil(func(app *govalin.App) *govalin.App {
 		app.HTTPServe("/httpserve", func(w http.ResponseWriter, _ *http.Request) {
-			_, err := w.Write([]byte("httpservegovalin"))
+			// Header must be written before the body; writing it afterwards is a
+			// superfluous WriteHeader call that net/http warns about.
 			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("httpservegovalin"))
 			assert.Nil(t, err, "Should write to response writer")
 		})
 

--- a/static.go
+++ b/static.go
@@ -66,6 +66,12 @@ Are you sure it exists on the given path: '%s'`, indexPath))
 
 	// file does not exist, serve index.html
 	call.Status(http.StatusOK)
+
+	// http.ServeFile takes over the raw writer and writes the response header
+	// itself. Bypass the lifecycle (same contract as HTTPServe) so the buffered
+	// status isn't flushed a second time, which would trigger a superfluous
+	// response.WriteHeader warning.
+	call.bypassLifecycle = true
 	http.ServeFile(*call.Raw.W, call.Raw.Req, filepath.Join(config.staticPath, "index.html"))
 }
 
@@ -165,6 +171,11 @@ func (config *StaticConfig) handle(call *Call) {
 		hostedFileSystem = http.Dir(config.staticPath)
 	}
 
+	// http.FileServer takes over the raw writer and writes the response header
+	// itself. Bypass the lifecycle (same contract as HTTPServe) so the buffered
+	// status isn't flushed a second time, which would trigger a superfluous
+	// response.WriteHeader warning.
+	call.bypassLifecycle = true
 	http.StripPrefix(
 		config.hostPath,
 		http.FileServer(hostedFileSystem),

--- a/writeheader_test.go
+++ b/writeheader_test.go
@@ -1,0 +1,121 @@
+package govalin_test
+
+import (
+	"bytes"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/pkkummermo/govalin"
+	"github.com/pkkummermo/govalin/internal/govalintesting"
+)
+
+// superfluousWriteHeaderWarning is the exact message net/http logs when a
+// response header is written more than once. Catching it guards against
+// handlers that delegate to the standard library file servers (or otherwise
+// take over the raw writer) without bypassing the govalin lifecycle, which
+// would flush the buffered status a second time.
+const superfluousWriteHeaderWarning = "superfluous response.WriteHeader call"
+
+// safeBuffer is a concurrency-safe buffer. net/http logs warnings from the
+// per-connection goroutines that serve requests, so writes to the capture
+// buffer can happen concurrently with each other.
+type safeBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *safeBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *safeBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// logCapture mirrors everything logged during the test run into memory. The
+// govalin server leaves http.Server.ErrorLog unset, so net/http logs its
+// warnings — including the superfluous WriteHeader warning — through the
+// standard log package, which slog.SetDefault re-routes through the slog
+// default handler. We therefore capture at the slog layer (see TestMain).
+var logCapture = &safeBuffer{}
+
+// TestMain installs a package-wide guard: it makes the slog default handler tee
+// every record into an in-memory buffer for the duration of the run, then fails
+// the whole run if any test triggered a superfluous response.WriteHeader
+// warning. Capturing at the slog layer (rather than via log.SetOutput) is what
+// makes this robust: slog.SetDefault re-routes the standard log package — where
+// net/http emits the warning — through the current slog handler, and the
+// access-log tests that swap the slog default restore it to whatever was
+// default when they started, i.e. this teeing handler. This way the regression
+// is caught no matter which test exercises the offending code path, not just
+// the dedicated test below.
+func TestMain(m *testing.M) {
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.MultiWriter(os.Stderr, logCapture), nil)))
+
+	code := m.Run()
+
+	slog.SetDefault(previous)
+
+	if captured := logCapture.String(); strings.Contains(captured, superfluousWriteHeaderWarning) {
+		for _, line := range strings.Split(captured, "\n") {
+			if strings.Contains(line, superfluousWriteHeaderWarning) {
+				_, _ = os.Stderr.WriteString("FAIL: " + line + "\n")
+			}
+		}
+		os.Exit(1)
+	}
+
+	os.Exit(code)
+}
+
+// TestStaticServingDoesNotDoubleWriteHeader explicitly drives every static
+// file-serving path so the lifecycle/file-server interaction is covered even if
+// no other test happens to hit it. The actual assertion lives in TestMain,
+// which inspects the captured net/http warnings for the whole package.
+func TestStaticServingDoesNotDoubleWriteHeader(t *testing.T) {
+	staticRoot, _ := fs.Sub(staticTestFiles, "internal/testdata/static")
+
+	// Embedded FS, both plain and SPA mode.
+	govalintesting.HTTPTestUtil(func(app *govalin.App) *govalin.App {
+		app.Static("/fs", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+			staticConfig.WithFS(staticRoot)
+		})
+		app.Static("/fs-spa", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+			staticConfig.WithFS(staticRoot).EnableSPAMode(true)
+		})
+		return app
+	}, func(http govalintesting.GovalinHTTP) {
+		http.Get("/fs/index.html")         // served via http.FileServer
+		http.Get("/fs/")                   // index via serveIndexFS
+		http.Get("/fs/sub/test.html")      // subfolder file via http.FileServer
+		http.Get("/fs/non-existing-path")  // 404 via http.FileServer
+		http.Get("/fs-spa/does-not-exist") // SPA fallback to index
+	})
+
+	// On-disk static directory, both plain and SPA mode.
+	govalintesting.HTTPTestUtil(func(app *govalin.App) *govalin.App {
+		app.Static("/static", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+			staticConfig.WithStaticPath("internal/testdata/static")
+		})
+		app.Static("/static-spa", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+			staticConfig.WithStaticPath("internal/testdata/static").EnableSPAMode(true)
+		})
+		return app
+	}, func(http govalintesting.GovalinHTTP) {
+		http.Get("/static/index.html")         // served via http.FileServer
+		http.Get("/static/")                   // index via serveIndexStatic (http.ServeFile)
+		http.Get("/static/sub/test.html")      // subfolder file via http.FileServer
+		http.Get("/static/non-existing-path")  // 404 via http.FileServer
+		http.Get("/static-spa/does-not-exist") // SPA fallback to index
+	})
+}


### PR DESCRIPTION
## Problem

Every static asset request logged `http: superfluous response.WriteHeader call`.

`Call.w` and `*Call.Raw.W` are the same `http.ResponseWriter`. In `static.go`, when `handle` delegates to `http.FileServer(...).ServeHTTP` (and `serveIndexStatic` to `http.ServeFile`), net/http writes the response header directly on that writer. Because `bypassLifecycle` stayed `false`, the lifecycle's deferred `call.sendStatusOrDefault()` then called `WriteHeader` a **second** time — the superfluous call. (The `serveIndexFS` path was unaffected because it routes through `call.HTML` → `sendStatusOrDefault`, writing once.)

## Fix

Set `call.bypassLifecycle = true` at the two points where the raw writer is handed to net/http — the same contract `HTTPServe` already uses (`serve-http.go:15`). The buffered `call.Status(...)` calls are kept so the access log still records a sensible status; they're simply no longer flushed to the wire.

## Regression guard

Added `writeheader_test.go`:

- **`TestMain`** tees the `slog` default handler into a buffer for the whole run and fails if any test emits a superfluous-WriteHeader warning. Capturing at the slog layer (not `log.SetOutput`) is deliberate: net/http logs through the standard `log` package, `slog.SetDefault` reroutes that through the slog handler, and the access-log tests restore the slog default to whatever was active when they started — so the guard survives them. This covers **every** test in the package.
- **`TestStaticServingDoesNotDoubleWriteHeader`** explicitly drives all static-serving paths (embedded FS + on-disk dir, plain + SPA, file/index/subfolder/404).

The guard surfaced a **pre-existing** second offender: the HTTPServe test wrote the body before `WriteHeader`. Reordered it to write the header first.

## Verification

- `go test ./...` passes.
- Reverting either `bypassLifecycle` line makes the full suite fail with the captured warning pointing at `(*Call).sendStatusOrDefault (call.go:238)` — confirming the guard bites rather than passing vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)