### PR TITLE
fix(mdns): route dnssd library logs through slog

### DIFF
--- a/plugins/mdns/mdns.go
+++ b/plugins/mdns/mdns.go
@@ -36,8 +36,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/brutella/dnssd"
+	dnssdlog "github.com/brutella/dnssd/log"
 	"github.com/pkkummermo/govalin"
 )
 
@@ -108,6 +110,8 @@ func (config *Config) OnInit(govalinConfig *govalin.Config) {
 // failures are non-fatal: they log an actionable warning and leave the HTTP
 // server untouched.
 func (config *Config) Apply(app *govalin.App) {
+	routeLibraryLogging()
+
 	port := app.Port()
 
 	service, serviceErr := dnssd.NewService(dnssd.Config{
@@ -221,6 +225,38 @@ func (config *Config) advertisementMessage(port uint16) string {
 	return fmt.Sprintf("mDNS plugin: advertising %q → %s:%d on the local network "+
 		"(browse with \"dns-sd -B %s\" or \"avahi-browse -a\")",
 		instance, host, port, config.serviceType)
+}
+
+// routeDnssdLogging guards the one-time, process-global redirection of the
+// dnssd library's logger so concurrent apps don't install it repeatedly.
+var routeDnssdLogging sync.Once
+
+// routeLibraryLogging redirects the dnssd library's package-level Info logger —
+// which otherwise writes raw, unstructured lines straight to stdout via the
+// standard log package — through slog at debug level. The library emits benign
+// Info lines such as "dnssd: unable to wait for link updates" (logged on every
+// non-Linux platform, where netlink link-change subscription is unavailable);
+// routing them keeps logging structured and out of the default-level output.
+//
+// The dnssd logger is package-global state, so this mutates logging for every
+// consumer of the library in the process; it runs at most once.
+func routeLibraryLogging() {
+	routeDnssdLogging.Do(func() {
+		dnssdlog.Info.SetFlags(0)
+		dnssdlog.Info.SetPrefix("")
+		dnssdlog.Info.SetOutput(dnssdSlogWriter{})
+	})
+}
+
+// dnssdSlogWriter adapts the dnssd library's stdlib *log.Logger output to slog,
+// emitting one debug record per logged line.
+type dnssdSlogWriter struct{}
+
+func (dnssdSlogWriter) Write(p []byte) (int, error) {
+	msg := strings.TrimSpace(string(p))
+	msg = strings.TrimSpace(strings.TrimPrefix(msg, "dnssd:"))
+	slog.Debug("mDNS plugin: " + msg)
+	return len(p), nil
 }
 
 func (config *Config) warnRuntimeFailure(err error) {


### PR DESCRIPTION
## Problem

The mDNS plugin logs `dnssd: unable to wait for link updates` at startup. The line is **not** from our code — it comes from the `brutella/dnssd` library at [`netlink_others.go:12`](https://github.com/brutella/dnssd/blob/v1.2.14/netlink_others.go#L12), which is compiled on every non-Linux platform (`//go:build !linux`) and unconditionally logs because netlink link-change subscription is Linux-only.

The library logs through its own `dnssd/log` package, which writes raw lines straight to `os.Stdout` via Go's stdlib `log` — bypassing slog. The result is benign-but-noisy, unstructured output cluttering the logs on macOS/Windows.

## Fix

The library exposes `dnssd/log.Info` as a configurable `*log.Logger`, so we redirect its output through slog:

- `routeLibraryLogging()` (called at the top of `Apply`) installs the redirect once via `sync.Once`, clearing the library's `INFO`/timestamp prefix.
- A small `io.Writer` adapter re-emits each line as `slog.Debug("mDNS plugin: …")`.

### Effect
- **No clutter by default** — slog's default handler drops debug records, so the line disappears from normal output.
- **Still available** — set your slog handler to debug and it returns, now structured and consistently prefixed.
- Covers all of the library's `Info`-level chatter, not just this one line.

### Trade-off
The dnssd logger is process-global package state, so the redirect affects any other consumer of `brutella/dnssd` in the same binary — in practice only this plugin. Documented in the helper's comment.

## Testing
`go build ./...`, `go vet ./plugins/mdns/`, and `go test ./plugins/mdns/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)