### PR TITLE
fix(ws): bypass lifecycle on websocket upgrade

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -113,7 +113,7 @@ Committing the buffered status to the writer. Happens on the first body write (J
 _Avoid_: implicit 200 on unflushed status, multiple status writes
 
 **Lifecycle bypass**:
-A request whose handler takes ownership of the raw writer (HTTPServe); govalin performs no status flush or response finalization for it.
+A request whose handler takes ownership of the raw writer (HTTPServe, or a websocket upgrade that hijacks the connection); govalin performs no status flush or response finalization for it.
 _Avoid_: framework-managed finalization on raw handlers, double-writing a bypassed response
 
 **Bound port**:

--- a/writeheader_test.go
+++ b/writeheader_test.go
@@ -14,12 +14,19 @@ import (
 	"github.com/pkkummermo/govalin/govalintest"
 )
 
-// superfluousWriteHeaderWarning is the exact message net/http logs when a
-// response header is written more than once. Catching it guards against
-// handlers that delegate to the standard library file servers (or otherwise
-// take over the raw writer) without bypassing the govalin lifecycle, which
-// would flush the buffered status a second time.
-const superfluousWriteHeaderWarning = "superfluous response.WriteHeader call"
+// writeHeaderWarnings are the net/http log messages that signal a handler took
+// over the raw writer without bypassing the govalin lifecycle, so the buffered
+// status got flushed a second time. Catching them guards against regressions:
+//   - "superfluous response.WriteHeader call" — a second WriteHeader on a
+//     normal response (e.g. a handler delegating to a standard-library file
+//     server without bypassing the lifecycle).
+//   - "response.WriteHeader on hijacked connection" — a WriteHeader on a
+//     connection a handler already hijacked (e.g. a websocket upgrade without a
+//     lifecycle bypass).
+var writeHeaderWarnings = []string{
+	"superfluous response.WriteHeader call",
+	"response.WriteHeader on hijacked connection",
+}
 
 // safeBuffer is a concurrency-safe buffer. net/http logs warnings from the
 // per-connection goroutines that serve requests, so writes to the capture
@@ -50,8 +57,9 @@ var logCapture = &safeBuffer{}
 
 // TestMain installs a package-wide guard: it makes the slog default handler tee
 // every record into an in-memory buffer for the duration of the run, then fails
-// the whole run if any test triggered a superfluous response.WriteHeader
-// warning. Capturing at the slog layer (rather than via log.SetOutput) is what
+// the whole run if any test triggered one of the writeHeaderWarnings (a second
+// WriteHeader on a normal response, or a WriteHeader on an already-hijacked
+// connection). Capturing at the slog layer (rather than via log.SetOutput) is what
 // makes this robust: slog.SetDefault re-routes the standard log package — where
 // net/http emits the warning — through the current slog handler, and the
 // access-log tests that swap the slog default restore it to whatever was
@@ -66,12 +74,16 @@ func TestMain(m *testing.M) {
 
 	slog.SetDefault(previous)
 
-	if captured := logCapture.String(); strings.Contains(captured, superfluousWriteHeaderWarning) {
-		for _, line := range strings.Split(captured, "\n") {
-			if strings.Contains(line, superfluousWriteHeaderWarning) {
+	failed := false
+	for _, line := range strings.Split(logCapture.String(), "\n") {
+		for _, warning := range writeHeaderWarnings {
+			if strings.Contains(line, warning) {
 				_, _ = os.Stderr.WriteString("FAIL: " + line + "\n")
+				failed = true
 			}
 		}
+	}
+	if failed {
 		os.Exit(1)
 	}
 

--- a/ws.go
+++ b/ws.go
@@ -178,6 +178,15 @@ func (server *App) Ws(path string, handlerFunc WsHandlerFunc) *App {
 
 	server.addMethod(http.MethodGet, server.currentFragment+path, func(call *Call) {
 		call.Status(http.StatusSwitchingProtocols)
+
+		// A websocket upgrade hijacks the connection (or, on failure, lets the
+		// upgrader write its own HTTP error), so the handler owns response
+		// finalization from here on — just like HTTPServe. Bypass the govalin
+		// lifecycle to suppress the end-of-request status flush, which would
+		// otherwise attempt a WriteHeader on the hijacked connection. See
+		// CONTEXT.md "Lifecycle bypass".
+		call.bypassLifecycle = true
+
 		wsCall, upgradeErr := wsConfig.OnUpgrade(call)
 
 		if upgradeErr != nil {


### PR DESCRIPTION
## Problem

Websocket upgrades hijack the connection, but `App.Ws()` never set `bypassLifecycle`. The end-of-lifecycle status flush in `rootHandlerFunc` (ADR 0002) then called `WriteHeader` on the hijacked connection, which `net/http` swallowed while logging:

```
http: response.WriteHeader on hijacked connection from github.com/pkkummermo/govalin.(*Call).sendStatusOrDefault (call.go:238)
```

Behavior was correct-by-accident, but the log was noise and the flush is conceptually wrong for a hijacked request.

## Fix

- **`ws.go`** — set `call.bypassLifecycle = true` in the websocket handler, mirroring `HTTPServe`. It is set *before* the upgrade so both paths are covered: the hijack on success, and the upgrader writing its own HTTP error on failure (which would otherwise trigger a *superfluous* `WriteHeader`).
- **`writeheader_test.go`** — the package-wide `TestMain` guard only caught `"superfluous response.WriteHeader call"`, which is why the ws tests passed despite the bug. Extended it to also fail on `"response.WriteHeader on hijacked connection"`, so the existing ws tests now serve as regression coverage — no new test machinery.
- **`CONTEXT.md`** — updated the "Lifecycle bypass" definition to note websocket upgrades also take ownership of the raw writer.

## Verification

- `go test ./` and `go test -race ./` pass; build clean; `golangci-lint` reports 0 issues.
- Confirmed the guard catches the regression: stashing the `ws.go` fix makes the suite fail with the exact warning from the issue; restoring it passes.

Fixes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)