### PR TITLE
fix(call): enforce body size limit correctly and read bodies efficiently

### DIFF
--- a/call.go
+++ b/call.go
@@ -45,6 +45,7 @@ type Call struct {
 	req             *http.Request
 	pathParams      map[string]string
 	bodyBytes       []byte
+	bodyErr         error
 	charset         string
 	session         session.Session
 	Raw             raw // Raw contains the raw request and response
@@ -149,32 +150,66 @@ func addNewSessionToCall(call *Call) error {
 	return nil
 }
 
+// errBodyTooLarge is returned when a request body exceeds the configured max
+// body read size. Never mutated, so sharing it across requests is safe.
+var errBodyTooLarge = validation.NewError(validation.NewErrorResponse(
+	http.StatusRequestEntityTooLarge,
+	validation.NewParameterErrorDetail(
+		"body",
+		"Request body exceeds the maximum allowed size",
+	),
+))
+
+// failBody caches a body read failure. A body can only be read once, so a
+// repeated read replays the failure instead of reporting an empty body.
+func (call *Call) failBody(err error) ([]byte, error) {
+	call.bodyBytes = []byte{}
+	call.bodyErr = err
+
+	return call.bodyBytes, err
+}
+
 // readBody reads the body as bytes and caches the value on call.
+//
+// A declared Content-Length gives an exactly sized allocation; unknown lengths
+// (chunked) fall back to a growing buffer capped by http.MaxBytesReader.
 func (call *Call) readBody() ([]byte, error) {
-	if call.bodyBytes != nil {
-		return call.bodyBytes, nil
+	if call.bodyBytes != nil || call.bodyErr != nil {
+		return call.bodyBytes, call.bodyErr
 	}
 
-	limitedReader := io.LimitReader(call.req.Body, call.config.server.maxBodyReadSize)
+	maxSize := call.config.server.maxBodyReadSize
 
-	bytes, err := io.ReadAll(limitedReader)
+	// Reject a declared oversized body before reading a single byte. Leaving it
+	// unread is deliberate: net/http drains a small overage and keeps the
+	// connection alive, and abandons a large one. Tripping MaxBytesReader here
+	// instead would force a teardown even on a body that is barely over.
+	if call.req.ContentLength > maxSize {
+		return call.failBody(errBodyTooLarge)
+	}
+
+	limitedReader := http.MaxBytesReader(call.w, call.req.Body, maxSize)
+
+	var body []byte
+	var err error
+
+	if call.req.ContentLength >= 0 {
+		body = make([]byte, call.req.ContentLength)
+		_, err = io.ReadFull(limitedReader, body)
+	} else {
+		body, err = io.ReadAll(limitedReader)
+	}
+
 	if err != nil {
-		call.bodyBytes = []byte{}
-		return []byte{}, fmt.Errorf("failed to read request body. %w", err)
-	}
-
-	// If the size of bytes read and max body read size is the same, we could have a too big of a body.
-	// Try to read a single byte to see if the body still has any data
-	if len(bytes) == int(call.config.server.maxBodyReadSize) {
-		numBytes, readError := call.req.Body.Read(make([]byte, 1))
-
-		if (readError == nil || errors.Is(readError, io.EOF)) && numBytes == 1 {
-			call.bodyBytes = []byte{}
-			return []byte{}, fmt.Errorf("request body was too big, could not read full body")
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			return call.failBody(errBodyTooLarge)
 		}
+
+		return call.failBody(fmt.Errorf("failed to read request body. %w", err))
 	}
 
-	call.bodyBytes = bytes
+	call.bodyBytes = body
 
 	return call.bodyBytes, nil
 }
@@ -644,7 +679,9 @@ func (call *Call) Error(err error) {
 
 	var validationErr *validation.Error
 	if errors.As(err, &validationErr) {
-		call.Status(http.StatusBadRequest)
+		// Use the status the error carries so non-400 validation errors surface
+		// their real status.
+		call.Status(validationErr.Status())
 		call.JSON(validationErr.ErrorResponse)
 		return
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -1,12 +1,21 @@
 package govalin_test
 
 import (
+	"net/http"
+	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/pkkummermo/govalin"
 	"github.com/pkkummermo/govalin/govalintest"
 	"github.com/stretchr/testify/assert"
 )
+
+// bodyTooLargeResponse is the response govalin writes when a request body
+// exceeds the configured max body read size.
+const bodyTooLargeResponse = `{"title":"Payload too large","status":413,` +
+	`"type":"https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413",` +
+	`"details":[{"field":"body","reason":"Request body exceeds the maximum allowed size"}]}`
 
 func TestServerMaxBodyReadSizeConfig(t *testing.T) {
 	newApp := govalin.New(func(config *govalin.Config) {
@@ -28,9 +37,10 @@ func TestServerMaxBodyReadSizeConfig(t *testing.T) {
 	govalintest.Test(t, newApp, func(client *govalintest.Client) {
 		response := client.PostResponse("/bodysize", `"aaa"`)
 		responseBody := readBody(t, response)
+		assert.Equal(t, http.StatusRequestEntityTooLarge, response.StatusCode)
 		assert.Equal(
 			t,
-			`{"title":"Server error","status":500,"type":"https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500"}`,
+			bodyTooLargeResponse,
 			responseBody,
 			"should trigger error upon max size",
 		)
@@ -55,9 +65,10 @@ func TestServerMaxBodyReadSizeConfig(t *testing.T) {
 	govalintest.Test(t, newApp, func(client *govalintest.Client) {
 		response := client.PostResponse("/bodysize", `"aaaaaaaa"`)
 		responseBody := readBody(t, response)
+		assert.Equal(t, http.StatusRequestEntityTooLarge, response.StatusCode)
 		assert.Equal(
 			t,
-			`{"title":"Server error","status":500,"type":"https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/500"}`,
+			bodyTooLargeResponse,
 			responseBody,
 			"should trigger error upon more than max size",
 		)
@@ -87,6 +98,86 @@ func TestServerMaxBodyReadSizeConfig(t *testing.T) {
 			`"aa"`,
 			responseBody,
 			"should not trigger error upon max size",
+		)
+	})
+}
+
+func TestServerMaxBodyReadSizeErrorIsReplayedOnReread(t *testing.T) {
+	newApp := govalin.New(func(config *govalin.Config) {
+		config.ServerMaxBodyReadSize(4)
+	})
+
+	newApp.Post("/bodysize", func(call *govalin.Call) {
+		var body string
+
+		assert.Error(t, call.BodyAs(&body), "first read should report the oversized body")
+
+		// The body is consumed, so a second read must replay the failure rather
+		// than hand back the empty cache as a success.
+		err := call.BodyAs(&body)
+
+		if err != nil {
+			call.Error(err)
+		} else {
+			call.JSON(body)
+		}
+	})
+
+	govalintest.Test(t, newApp, func(client *govalintest.Client) {
+		response := client.PostResponse("/bodysize", `"aaaaaaaa"`)
+		assert.Equal(t, http.StatusRequestEntityTooLarge, response.StatusCode)
+		assert.Equal(t, bodyTooLargeResponse, readBody(t, response))
+	})
+}
+
+func TestServerMaxBodyReadSizeWithoutContentLength(t *testing.T) {
+	var observedLength atomic.Int64
+
+	newApp := govalin.New(func(config *govalin.Config) {
+		config.ServerMaxBodyReadSize(4)
+		// Aborting an oversized body makes net/http linger 500ms on the
+		// half-closed connection so the client reads the 413 instead of an RST,
+		// which outlasts the default 200ms shutdown timeout.
+		config.ServerShutdownTimeout(2000)
+	})
+
+	newApp.Post("/bodysize", func(call *govalin.Call) {
+		var body string
+
+		observedLength.Store(call.Raw.Req.ContentLength)
+
+		err := call.BodyAs(&body)
+
+		if err != nil {
+			call.Error(err)
+		} else {
+			call.JSON(body)
+		}
+	})
+
+	govalintest.Test(t, newApp, func(client *govalintest.Client) {
+		chunkedRequest := func(body string) *http.Request {
+			req, err := http.NewRequest(http.MethodPost, "/bodysize", strings.NewReader(body))
+			assert.NoError(t, err)
+			req.ContentLength = -1 // Force chunked encoding.
+			return req
+		}
+
+		response := client.Do(chunkedRequest(`"aa"`))
+		// Guards the premise: an unknown length is what routes readBody down its
+		// growing-buffer branch.
+		assert.Equal(t, int64(-1), observedLength.Load(), "server should see an unknown body length")
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+		assert.Equal(t, `"aa"`, readBody(t, response), "chunked body within the limit should be read")
+
+		response = client.Do(chunkedRequest(`"aaaaaaaa"`))
+		assert.Equal(t, int64(-1), observedLength.Load(), "server should see an unknown body length")
+		assert.Equal(t, http.StatusRequestEntityTooLarge, response.StatusCode)
+		assert.Equal(
+			t,
+			bodyTooLargeResponse,
+			readBody(t, response),
+			"chunked body over the limit should be rejected",
 		)
 	})
 }

--- a/internal/validation/error-response.go
+++ b/internal/validation/error-response.go
@@ -13,6 +13,7 @@ var defaultErrorMessages = map[int]string{
 	404: "Not found",
 	405: "Method not allowed",
 	409: "Conflict",
+	413: "Payload too large",
 	500: "Server error",
 	501: "Not implemented",
 	502: "Bad gateway",

--- a/internal/validation/error.go
+++ b/internal/validation/error.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"fmt"
+	"net/http"
 )
 
 // Error is an error who occured when trying to validate an entity
@@ -17,6 +18,16 @@ func (validationError *Error) Error() string {
 		validationError.ErrorResponse.Title,
 		validationError.ErrorResponse.Details,
 	)
+}
+
+// Status returns the HTTP status the error carries, falling back to 400 for an
+// error without a response.
+func (validationError *Error) Status() int {
+	if validationError.ErrorResponse == nil {
+		return http.StatusBadRequest
+	}
+
+	return validationError.ErrorResponse.Status
 }
 
 // NewError returns an error based on a validation error response.


### PR DESCRIPTION
## Why

`readBody` hand-rolled its size limit: read up to `maxBodyReadSize` with `io.LimitReader`, then probe for one extra byte to decide whether the body was too big. Three problems fell out of that:

1. **The probe leaks.** It required `Read` to return exactly 1 byte to conclude "too big", but a `Read` is allowed to return `(0, nil)` with more data behind it — so a trickling client could push an oversized body straight past the check. It could also block on the raw body waiting for a client that wasn't sending.
2. **`io.ReadAll` re-allocates and re-copies.** It starts at a 512-byte buffer and doubles, so the default 4096 cap costs several allocations and copies per request — while `Content-Length` was sitting right there on the request.
3. **Oversized bodies reported 500.** They returned a bare `fmt.Errorf` that `Call.Error` didn't recognise, so they fell through to "Unknown error" → `500 Server error`.

## What changed

- **`http.MaxBytesReader` owns the limit** instead of the hand-rolled probe. It stops the read at the cap and lets the server tear the connection down on abuse.
- **A declared `Content-Length` over the limit is rejected before a single byte is read.** Leaving that body unread is deliberate — `net/http` drains a small overage and keeps the connection healthy, and abandons a large one. Tripping the limiter there instead would force a teardown even on a body that's barely over.
- **Reads are right-sized.** A declared `Content-Length` gives one exactly sized allocation via `io.ReadFull`. Only unknown lengths (chunked) still use a growing buffer.
- **Oversized bodies now return 413**, carried by a `validation.Error`. `Call.Error` uses the status the validation error carries rather than hardcoding 400, which is also the correct behaviour for any non-400 validation error added later.
- **Read failures are cached alongside the body**, so a second `BodyAs` on the same call replays the failure instead of reporting an empty body as success.

## Behaviour change

**A request body over `ServerMaxBodyReadSize` now responds `413 Payload too large` instead of `500 Server error`.** The three existing assertions in `config_test.go` were updated to match.

One thing worth knowing: when `MaxBytesReader` aborts a body, `net/http` half-closes the connection and lingers 500ms (`rstAvoidanceDelay`) so the client is guaranteed to read the 413 rather than catch an RST. The default `ServerShutdownTimeout` is **200ms**, shorter than that linger, so a graceful shutdown immediately after rejecting an oversized *chunked* body will report `context deadline exceeded`. The new chunked test sets a longer timeout rather than changing the default — raising the default is a separate call.

## Tests

- Existing `TestServerMaxBodyReadSizeConfig` assertions moved 500 → 413.
- `TestServerMaxBodyReadSizeWithoutContentLength` covers the chunked branch, which the `Content-Length` cases never reach.
- `TestServerMaxBodyReadSizeErrorIsReplayedOnReread` covers the new replay guarantee.

`go vet`, `golangci-lint` (0 issues) and `go test -race -count=1 ./...` all pass.

## Not in scope

`parseForm` bypasses `maxBodyReadSize` entirely for form bodies, and `ParseMultipartForm(0)` spills every upload to a temp file. Deliberately left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
