### PR TITLE
feat(call): bound form bodies and multipart uploads by configured limits

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -144,6 +144,27 @@ _Avoid_: helpers that auto-fail on non-2xx, status assertions hidden inside body
 A test utility failure fails the calling test (`t.Fatalf`/`t.Errorf`), never the process. Process exit in a helper kills the whole test binary and destroys the test report.
 _Avoid_: `os.Exit` in test helpers, one failed request aborting the suite
 
+**Body size limit**:
+The maximum request body the server will accept and read into memory, covering JSON/raw bodies and
+URL-encoded forms. Enforced on every path that reads a body, never left to net/http's own default.
+_Avoid_: per-path limits, "the framework caps it somewhere"
+
+**Multipart size limit**:
+The total size ceiling for a multipart request body. Separate from the **Body size limit**, whose
+default is sized for JSON payloads and would reject every upload.
+_Avoid_: one limit for all body shapes, uncapped uploads
+
+**Multipart memory budget**:
+How much of a multipart form is held in memory before parts spill to temporary files. Bounds memory
+pressure only — it is not a limit on what the server accepts.
+_Avoid_: budget-as-size-cap, zero budget forcing every upload to disk
+
+**Declared-length rejection**:
+Refusing a body whose `Content-Length` already exceeds its limit, before reading a byte, rather than
+letting the read trip the limiter. Keeps a marginally-oversized request from costing a connection
+teardown.
+_Avoid_: read-then-discard, limiter-only enforcement
+
 **Actionable runtime warning**:
 A non-fatal log emitted when an auxiliary runtime operation fails (e.g. mDNS registration/broadcast) must state what went wrong and what the user can do to fix it — not merely that an operation failed. Misconfiguration, by contrast, is caught early and is fatal.
 _Avoid_: "failed to start/configure" with no cause or remedy, silent runtime degradation
@@ -179,6 +200,8 @@ _Avoid_: "failed to start/configure" with no cause or remedy, silent runtime deg
 - The **App-under-test** relies on **Startup-event readiness**, which reads the **Bound port** only after the startup event fires
 - **Test-scoped failure** and **Status-agnostic body access** define the public test client's failure semantics: transport errors fail the test, HTTP error statuses do not
 - The **Plugin complexity boundary** does not exclude test tooling from the core module: a test package adds no dependency cost to consumers who never import it
+- The **Body size limit** and the **Multipart size limit** bound what the server accepts; the **Multipart memory budget** bounds only where an accepted upload is stored
+- **Declared-length rejection** is the first enforcement step for every limit, with the limiter as the fallback for bodies of unknown length
 
 ## Example dialogue
 

--- a/call.go
+++ b/call.go
@@ -46,6 +46,8 @@ type Call struct {
 	pathParams      map[string]string
 	bodyBytes       []byte
 	bodyErr         error
+	formParsed      bool
+	formErr         error
 	charset         string
 	session         session.Session
 	Raw             raw // Raw contains the raw request and response
@@ -160,6 +162,28 @@ var errBodyTooLarge = validation.NewError(validation.NewErrorResponse(
 	),
 ))
 
+// isBodyTooLarge reports whether a read failed because the body outgrew its limit.
+func isBodyTooLarge(err error) bool {
+	var maxBytesErr *http.MaxBytesError
+
+	return errors.As(err, &maxBytesErr) || errors.Is(err, multipart.ErrMessageTooLarge)
+}
+
+// limitBody caps the request body at maxSize for every reader that follows.
+//
+// A declared oversized body is rejected unread, since net/http then drains a
+// small overage and abandons a large one. Relying on MaxBytesReader alone would
+// force a connection teardown even on a body that is barely over.
+func (call *Call) limitBody(maxSize int64) error {
+	if call.req.ContentLength > maxSize {
+		return errBodyTooLarge
+	}
+
+	call.req.Body = http.MaxBytesReader(call.w, call.req.Body, maxSize)
+
+	return nil
+}
+
 // failBody caches a body read failure. A body can only be read once, so a
 // repeated read replays the failure instead of reporting an empty body.
 func (call *Call) failBody(err error) ([]byte, error) {
@@ -172,37 +196,28 @@ func (call *Call) failBody(err error) ([]byte, error) {
 // readBody reads the body as bytes and caches the value on call.
 //
 // A declared Content-Length gives an exactly sized allocation; unknown lengths
-// (chunked) fall back to a growing buffer capped by http.MaxBytesReader.
+// (chunked) fall back to a growing buffer.
 func (call *Call) readBody() ([]byte, error) {
 	if call.bodyBytes != nil || call.bodyErr != nil {
 		return call.bodyBytes, call.bodyErr
 	}
 
-	maxSize := call.config.server.maxBodyReadSize
-
-	// Reject a declared oversized body before reading a single byte. Leaving it
-	// unread is deliberate: net/http drains a small overage and keeps the
-	// connection alive, and abandons a large one. Tripping MaxBytesReader here
-	// instead would force a teardown even on a body that is barely over.
-	if call.req.ContentLength > maxSize {
-		return call.failBody(errBodyTooLarge)
+	if err := call.limitBody(call.config.server.maxBodyReadSize); err != nil {
+		return call.failBody(err)
 	}
-
-	limitedReader := http.MaxBytesReader(call.w, call.req.Body, maxSize)
 
 	var body []byte
 	var err error
 
 	if call.req.ContentLength >= 0 {
 		body = make([]byte, call.req.ContentLength)
-		_, err = io.ReadFull(limitedReader, body)
+		_, err = io.ReadFull(call.req.Body, body)
 	} else {
-		body, err = io.ReadAll(limitedReader)
+		body, err = io.ReadAll(call.req.Body)
 	}
 
 	if err != nil {
-		var maxBytesErr *http.MaxBytesError
-		if errors.As(err, &maxBytesErr) {
+		if isBodyTooLarge(err) {
 			return call.failBody(errBodyTooLarge)
 		}
 
@@ -214,51 +229,126 @@ func (call *Call) readBody() ([]byte, error) {
 	return call.bodyBytes, nil
 }
 
+// errInvalidFormData is returned when a form body cannot be parsed.
+var errInvalidFormData = validation.NewError(validation.NewErrorResponse(
+	http.StatusBadRequest,
+	validation.NewParameterErrorDetail(
+		"formData",
+		"Invalid form data",
+	),
+))
+
+// errNotMultipartForm is returned when files are requested from a form that
+// cannot carry them.
+var errNotMultipartForm = validation.NewError(validation.NewErrorResponse(
+	http.StatusBadRequest,
+	validation.NewParameterErrorDetail(
+		headers.ContentType,
+		"Files require a '"+contenttypes.MultipartFormData+"' body",
+	),
+))
+
+// errBodyAlreadyRead is returned when a form is parsed from a drained body.
+var errBodyAlreadyRead = validation.NewError(validation.NewErrorResponse(
+	http.StatusInternalServerError,
+	validation.NewParameterErrorDetail(
+		"body",
+		"Request body was already read and can no longer be parsed as a form",
+	),
+))
+
+// errMissingFormContentType is returned when a Content-Type cannot carry a form.
+var errMissingFormContentType = validation.NewError(validation.NewErrorResponse(
+	http.StatusBadRequest,
+	validation.NewParameterErrorDetail(
+		headers.ContentType,
+		"Missing or invalid '"+headers.ContentType+"' header. "+
+			"Must be '"+contenttypes.MultipartFormData+"' or "+
+			"'"+contenttypes.ApplicationFormURLEncoded+"'",
+	),
+))
+
+// cacheForm records the parse outcome so FormParam, FormParams, File and Files
+// all report the same result.
+func (call *Call) cacheForm(err error) error {
+	call.formParsed = true
+	call.formErr = err
+
+	return err
+}
+
+// toFormError reports an oversized form as 413 rather than as malformed input.
+func toFormError(err error) error {
+	if isBodyTooLarge(err) {
+		return errBodyTooLarge
+	}
+
+	return errInvalidFormData
+}
+
 // parseForm parses the internal request form based on Content-Type. If the Content-Type
 // is not recognized, it returns a validation error.
 func (call *Call) parseForm() error {
+	if call.formParsed {
+		return call.formErr
+	}
+
+	// A drained body would otherwise parse as an empty form.
+	if call.bodyBytes != nil || call.bodyErr != nil {
+		return call.cacheForm(errBodyAlreadyRead)
+	}
+
 	contentType := call.Header(headers.ContentType)
 
 	switch {
 	case strings.Contains(contentType, contenttypes.ApplicationFormURLEncoded):
-		err := call.req.ParseForm()
-		if err != nil {
-			slog.Error("Failed to parse form data", "err", err)
-			return validation.NewError(validation.NewErrorResponse(
-				http.StatusBadRequest,
-				validation.NewParameterErrorDetail(
-					"formData",
-					"Invalid form data",
-				),
-			))
-		}
-		return nil
+		return call.cacheForm(call.parseURLEncodedForm())
 	case strings.Contains(contentType, contenttypes.MultipartFormData):
-		err := call.req.ParseMultipartForm(0)
-		if err != nil {
-			slog.Error("Failed to parse form data", "err", err)
-			return validation.NewError(validation.NewErrorResponse(
-				http.StatusBadRequest,
-				validation.NewParameterErrorDetail(
-					"formData",
-					"Invalid form data",
-				),
-			))
-		}
-
-		return nil
+		return call.cacheForm(call.parseMultipartForm())
 	default:
 		slog.Warn("POST request is missing the correct content-type to parse form param")
-		return validation.NewError(validation.NewErrorResponse(
-			http.StatusBadRequest,
-			validation.NewParameterErrorDetail(
-				headers.ContentType,
-				"Missing or invalid '"+headers.ContentType+"' header. "+
-					"Must be '"+contenttypes.MultipartFormData+"' or "+
-					"'"+contenttypes.ApplicationFormURLEncoded+"'",
-			),
-		))
+		return call.cacheForm(errMissingFormContentType)
 	}
+}
+
+func (call *Call) parseURLEncodedForm() error {
+	if err := call.limitBody(call.config.server.maxBodyReadSize); err != nil {
+		return err
+	}
+
+	if err := call.req.ParseForm(); err != nil {
+		slog.Error("Failed to parse form data", "err", err)
+		return toFormError(err)
+	}
+
+	return nil
+}
+
+func (call *Call) parseMultipartForm() error {
+	if err := call.limitBody(call.config.server.maxMultipartSize); err != nil {
+		return err
+	}
+
+	if err := call.req.ParseMultipartForm(call.config.server.maxMultipartMemory); err != nil {
+		slog.Error("Failed to parse form data", "err", err)
+		return toFormError(err)
+	}
+
+	return nil
+}
+
+// multipartForm returns the parsed multipart form, or an error when the request
+// carried a form that holds no files.
+func (call *Call) multipartForm() (*multipart.Form, error) {
+	if err := call.parseForm(); err != nil {
+		return nil, err
+	}
+
+	if call.req.MultipartForm == nil {
+		return nil, errNotMultipartForm
+	}
+
+	return call.req.MultipartForm, nil
 }
 
 func (call *Call) sendStatusOrDefault() {
@@ -360,12 +450,12 @@ func (call *Call) FormParams() (url.Values, error) {
 
 // File returns a FileHeader for given file name in the request body.
 func (call *Call) File(key string) (*multipart.FileHeader, error) {
-	err := call.parseForm()
+	form, err := call.multipartForm()
 	if err != nil {
 		return nil, err
 	}
 
-	if file, ok := call.req.MultipartForm.File[key]; ok {
+	if file, ok := form.File[key]; ok {
 		return file[0], nil
 	}
 
@@ -380,12 +470,12 @@ func (call *Call) File(key string) (*multipart.FileHeader, error) {
 
 // Files returns an array for the given file name in the request body.
 func (call *Call) Files(key string) ([]*multipart.FileHeader, error) {
-	err := call.parseForm()
+	form, err := call.multipartForm()
 	if err != nil {
 		return nil, err
 	}
 
-	if file, ok := call.req.MultipartForm.File[key]; ok {
+	if file, ok := form.File[key]; ok {
 		return file, nil
 	}
 

--- a/call_test.go
+++ b/call_test.go
@@ -3,6 +3,9 @@ package govalin_test
 import (
 	"net/http"
 	"net/http/cookiejar"
+	"net/url"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/pkkummermo/govalin"
@@ -439,5 +442,201 @@ func TestRedirect(t *testing.T) {
 
 		assert.Equal(t, 200, response.StatusCode)
 		assert.Equal(t, "govalin2", body)
+	})
+}
+
+func TestFormParamRespectsMaxBodyReadSize(t *testing.T) {
+	app := newTestApp(func(config *govalin.Config) {
+		config.ServerMaxBodyReadSize(32)
+	})
+	app.Post("/form", func(call *govalin.Call) {
+		value, err := call.FormParam("name")
+
+		if err != nil {
+			call.Error(err)
+		} else {
+			call.Text(value)
+		}
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.Do(urlEncodedRequest(t, "/form", url.Values{"name": {"govalin"}}))
+		assert.Equal(t, http.StatusOK, response.StatusCode)
+		assert.Equal(t, "govalin", readBody(t, response), "a form within the limit should parse")
+
+		response = client.Do(urlEncodedRequest(t, "/form", url.Values{"name": {strings.Repeat("a", 64)}}))
+		assert.Equal(
+			t,
+			http.StatusRequestEntityTooLarge,
+			response.StatusCode,
+			"a form over the limit should be rejected rather than parsed against net/http's own default",
+		)
+		assert.Equal(t, bodyTooLargeResponse, readBody(t, response))
+	})
+}
+
+func TestMultipartFormIsNotBoundByMaxBodyReadSize(t *testing.T) {
+	app := newTestApp(func(config *govalin.Config) {
+		// Far smaller than the upload below.
+		config.ServerMaxBodyReadSize(4)
+	})
+	app.Post("/upload", func(call *govalin.Call) {
+		file, err := call.File("upload")
+
+		if err != nil {
+			call.Error(err)
+		} else {
+			call.Text(file.Filename)
+		}
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.Do(multipartRequest(t, "/upload", "upload", strings.Repeat("a", 4096)))
+		assert.Equal(t, http.StatusOK, response.StatusCode, "uploads should be bounded by the multipart limit")
+		assert.Equal(t, "upload.txt", readBody(t, response))
+	})
+}
+
+func TestMultipartFormRespectsMaxMultipartSize(t *testing.T) {
+	app := newTestApp(func(config *govalin.Config) {
+		config.ServerMaxMultipartSize(256)
+	})
+	app.Post("/upload", func(call *govalin.Call) {
+		file, err := call.File("upload")
+
+		if err != nil {
+			call.Error(err)
+		} else {
+			call.Text(file.Filename)
+		}
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.Do(multipartRequest(t, "/upload", "upload", strings.Repeat("a", 4096)))
+		assert.Equal(t, http.StatusRequestEntityTooLarge, response.StatusCode)
+		assert.Equal(t, bodyTooLargeResponse, readBody(t, response))
+	})
+}
+
+// TestMultipartFormMemoryBudget pins where an uploaded part is stored: the
+// handler reports "disk" when net/http spilled it to a temporary file.
+func TestMultipartFormMemoryBudget(t *testing.T) {
+	storageHandler := func(call *govalin.Call) {
+		file, err := call.File("upload")
+		if err != nil {
+			call.Error(err)
+			return
+		}
+
+		opened, err := file.Open()
+		if err != nil {
+			call.Error(err)
+			return
+		}
+		defer func() { _ = opened.Close() }()
+
+		if _, onDisk := opened.(*os.File); onDisk {
+			call.Text("disk")
+		} else {
+			call.Text("memory")
+		}
+	}
+
+	app := newTestApp()
+	app.Post("/upload", storageHandler)
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.Do(multipartRequest(t, "/upload", "upload", strings.Repeat("a", 4096)))
+		assert.Equal(
+			t,
+			"memory",
+			readBody(t, response),
+			"an upload within the default budget should be held in memory",
+		)
+	})
+
+	app = newTestApp(func(config *govalin.Config) {
+		config.ServerMaxMultipartMemory(0)
+	})
+	app.Post("/upload", storageHandler)
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.Do(multipartRequest(t, "/upload", "upload", strings.Repeat("a", 4096)))
+		assert.Equal(t, "disk", readBody(t, response), "a zero budget should spill the upload to disk")
+	})
+}
+
+func TestFormErrorIsReplayedAcrossAccessors(t *testing.T) {
+	app := newTestApp(func(config *govalin.Config) {
+		config.ServerMaxBodyReadSize(32)
+	})
+	app.Post("/form", func(call *govalin.Call) {
+		_, firstErr := call.FormParam("name")
+		assert.Error(t, firstErr, "first access should report the oversized form")
+
+		// The body is consumed, so later accessors must replay the failure.
+		_, err := call.FormParams()
+		if err != nil {
+			call.Error(err)
+			return
+		}
+
+		call.Text("parsed")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.Do(urlEncodedRequest(t, "/form", url.Values{"name": {strings.Repeat("a", 64)}}))
+		assert.Equal(t, http.StatusRequestEntityTooLarge, response.StatusCode)
+		assert.Equal(t, bodyTooLargeResponse, readBody(t, response))
+	})
+}
+
+func TestFileOnNonMultipartForm(t *testing.T) {
+	app := newTestApp()
+	app.Post("/f", func(call *govalin.Call) {
+		file, err := call.File("upload")
+
+		if err != nil {
+			call.Error(err)
+		} else {
+			call.Text(file.Filename)
+		}
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.Do(urlEncodedRequest(t, "/f", url.Values{"name": {"govalin"}}))
+		assert.Equal(
+			t,
+			http.StatusBadRequest,
+			response.StatusCode,
+			"asking for a file on a url-encoded form should error rather than panic",
+		)
+	})
+}
+
+func TestFormAfterBodyReadIsRejected(t *testing.T) {
+	app := newTestApp()
+	app.Post("/f", func(call *govalin.Call) {
+		var body string
+		_ = call.BodyAs(&body)
+
+		// The body is drained, so the form would otherwise parse as empty.
+		value, err := call.FormParam("name")
+
+		if err != nil {
+			call.Error(err)
+		} else {
+			call.Text("parsed " + value)
+		}
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.Do(urlEncodedRequest(t, "/f", url.Values{"name": {"govalin"}}))
+		assert.Equal(
+			t,
+			http.StatusInternalServerError,
+			response.StatusCode,
+			"a drained body should report an error rather than a silently empty form",
+		)
 	})
 }

--- a/config.go
+++ b/config.go
@@ -10,6 +10,8 @@ const (
 	defaultPort                      = 6060               // govalin default port.
 	defaultMaxReadTimeout            = 10                 // maximum read timeout for requests.
 	defaultMaxBodyReadSize     int64 = 4096               //  Default max body read size.
+	defaultMaxMultipartMemory  int64 = 32 << 20           // Default in-memory budget for multipart parts.
+	defaultMaxMultipartSize    int64 = 128 << 20          // Default max size of a multipart body.
 	defaultShutdownTimeoutInMS       = 200                // Max time for shutdown.
 	defaultSessionExpireTime         = 3600 * time.Second // Default session expire time.
 )
@@ -22,6 +24,8 @@ type serverConfig struct {
 	port                uint16
 	maxReadTimeout      int64
 	maxBodyReadSize     int64
+	maxMultipartMemory  int64
+	maxMultipartSize    int64
 	shutdownTimeoutInMS int64
 	accessLogEnabled    bool
 	startupLogEnabled   bool
@@ -85,6 +89,24 @@ func (config *Config) ServerMaxBodyReadSize(maxReadSize int64) *Config {
 	return config
 }
 
+// ServerMaxMultipartMemory sets how much of a multipart form is held in memory.
+//
+// Parts beyond it spill to temporary files. It does not cap the request itself;
+// use ServerMaxMultipartSize for that.
+func (config *Config) ServerMaxMultipartMemory(maxMemory int64) *Config {
+	config.server.maxMultipartMemory = maxMemory
+	return config
+}
+
+// ServerMaxMultipartSize sets the max size to accept for a multipart request body.
+//
+// Uploads are bounded by this rather than by ServerMaxBodyReadSize, whose
+// default is sized for JSON payloads.
+func (config *Config) ServerMaxMultipartSize(maxSize int64) *Config {
+	config.server.maxMultipartSize = maxSize
+	return config
+}
+
 // ServerMaxReadTimeout sets the max read timeout for requests towards the Govalin server.
 func (config *Config) ServerMaxReadTimeout(timeout int64) *Config {
 	config.server.maxReadTimeout = timeout
@@ -132,6 +154,8 @@ func newConfig() *Config {
 			port:                defaultPort,
 			maxReadTimeout:      defaultMaxReadTimeout,
 			maxBodyReadSize:     defaultMaxBodyReadSize,
+			maxMultipartMemory:  defaultMaxMultipartMemory,
+			maxMultipartSize:    defaultMaxMultipartSize,
 			shutdownTimeoutInMS: defaultShutdownTimeoutInMS,
 			sessionsEnabled:     false,
 			accessLogEnabled:    true,

--- a/config_test.go
+++ b/config_test.go
@@ -11,14 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// bodyTooLargeResponse is the response govalin writes when a request body
-// exceeds the configured max body read size.
-const bodyTooLargeResponse = `{"title":"Payload too large","status":413,` +
-	`"type":"https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413",` +
-	`"details":[{"field":"body","reason":"Request body exceeds the maximum allowed size"}]}`
-
 func TestServerMaxBodyReadSizeConfig(t *testing.T) {
-	newApp := govalin.New(func(config *govalin.Config) {
+	newApp := newTestApp(func(config *govalin.Config) {
 		config.ServerMaxBodyReadSize(4)
 	})
 
@@ -46,7 +40,7 @@ func TestServerMaxBodyReadSizeConfig(t *testing.T) {
 		)
 	})
 
-	newApp = govalin.New(func(config *govalin.Config) {
+	newApp = newTestApp(func(config *govalin.Config) {
 		config.ServerMaxBodyReadSize(4)
 	})
 
@@ -74,7 +68,7 @@ func TestServerMaxBodyReadSizeConfig(t *testing.T) {
 		)
 	})
 
-	newApp = govalin.New(func(config *govalin.Config) {
+	newApp = newTestApp(func(config *govalin.Config) {
 		config.ServerMaxBodyReadSize(4)
 	})
 
@@ -103,7 +97,7 @@ func TestServerMaxBodyReadSizeConfig(t *testing.T) {
 }
 
 func TestServerMaxBodyReadSizeErrorIsReplayedOnReread(t *testing.T) {
-	newApp := govalin.New(func(config *govalin.Config) {
+	newApp := newTestApp(func(config *govalin.Config) {
 		config.ServerMaxBodyReadSize(4)
 	})
 
@@ -133,11 +127,11 @@ func TestServerMaxBodyReadSizeErrorIsReplayedOnReread(t *testing.T) {
 func TestServerMaxBodyReadSizeWithoutContentLength(t *testing.T) {
 	var observedLength atomic.Int64
 
-	newApp := govalin.New(func(config *govalin.Config) {
+	newApp := newTestApp(func(config *govalin.Config) {
 		config.ServerMaxBodyReadSize(4)
-		// Aborting an oversized body makes net/http linger 500ms on the
-		// half-closed connection so the client reads the 413 instead of an RST,
-		// which outlasts the default 200ms shutdown timeout.
+		// Without a declared length there is nothing to pre-check, so the read
+		// trips MaxBytesReader and net/http lingers 500ms on the connection,
+		// outlasting the default 200ms shutdown timeout.
 		config.ServerShutdownTimeout(2000)
 	})
 

--- a/docs/adr/0005-bounded-request-body-and-form-limits.md
+++ b/docs/adr/0005-bounded-request-body-and-form-limits.md
@@ -1,0 +1,65 @@
+# Bounded request body and form limits
+
+## Status
+
+accepted
+
+## Context and decision
+
+`ServerMaxBodyReadSize` documents itself as "the max read size to accept from POST requests ... to
+control DDoS attacks using big body sizes", but only `readBody` ever honoured it. `parseForm` called
+`ParseForm`/`ParseMultipartForm` directly, so form POSTs silently fell back to net/http's own 10MB
+allowance, and `ParseMultipartForm(0)` gave uploads a zero in-memory budget — every part was written
+to a temp file, with the on-disk copy bounded by nothing at all.
+
+Applying `maxBodyReadSize` to every body shape does not work: its 4096 default is sized for JSON, and
+would reject every file upload. Multipart therefore gets its own limits, and the configured cap now
+binds all three paths:
+
+- **Body reads and URL-encoded forms** are bound by `ServerMaxBodyReadSize` (default 4096). These are
+  the payload shapes that default sizing was written for.
+- **Multipart bodies** are bound by `ServerMaxMultipartSize` (default 128 MiB) — a **total upload
+  size** ceiling, replacing the previous absence of one.
+- **`ServerMaxMultipartMemory`** (default 32 MiB, matching net/http's own `defaultMaxMemory`) is a
+  distinct axis: how much of a multipart form is held in memory before parts spill to temporary files.
+  It bounds memory pressure, not what the server will accept.
+
+Limits are enforced by one helper, `limitBody`, shared by both paths. It rejects a body whose declared
+`Content-Length` already exceeds the limit *before* reading a byte, and otherwise wraps the body in
+`http.MaxBytesReader`. The declared-length pre-check is deliberate: tripping `MaxBytesReader` makes
+net/http half-close the connection and linger 500ms to avoid RSTing the client, so a body that is
+barely over would cost a teardown. Left unread instead, net/http drains a small overage and keeps the
+connection alive, and abandons a large one.
+
+Exceeding any limit is reported as **413**, replacing a 500 for oversized bodies and a generic 400
+"Invalid form data" for oversized forms.
+
+## Considered options
+
+- **Separate multipart limits (chosen)** — see above.
+- **One limit for every body shape** — simplest surface, but either 4096 breaks all uploads or an
+  upload-sized default removes the small, safe JSON ceiling that the option exists to provide.
+  Rejected.
+- **A single multipart limit doubling as both size cap and memory budget** — fewer knobs, but the two
+  bound different resources: accepting a 100MB upload streamed to disk is reasonable where holding
+  100MB in memory is not. Rejected as conflating them.
+- **Leaving multipart uncapped, memory budget only** — fixes the disk-spill complaint alone and leaves
+  unbounded disk writes, which is the more serious of the two faults. Rejected.
+- **Relying on `MaxBytesReader` alone, with no declared-length pre-check** — one code path, but every
+  marginally-oversized request pays a connection teardown plus a 500ms linger. Rejected.
+
+## Consequences
+
+- **Breaking**: URL-encoded forms larger than `ServerMaxBodyReadSize` (default 4096) are now rejected;
+  they previously got net/http's 10MB allowance. Applications posting large forms must raise the limit.
+- **Breaking**: oversized bodies and forms return 413 instead of 500/400 respectively. Clients matching
+  on the old statuses need updating.
+- Multipart uploads are no longer forced to disk, so a typical upload within the memory budget avoids
+  temp-file I/O entirely.
+- The parse outcome is cached per call, so the repeated `parseForm` calls behind `FormParam`,
+  `FormParams`, `File` and `Files` report one consistent result instead of the later ones observing a
+  drained body as an empty form.
+- Rejecting an oversized body without a declared `Content-Length` (chunked) still trips
+  `MaxBytesReader`, so such a request holds its connection for net/http's 500ms linger. The default
+  `ServerShutdownTimeout` of 200ms is shorter than that window, so a shutdown immediately after such a
+  rejection will report a timeout.

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,12 +1,24 @@
 package govalin_test
 
 import (
+	"bytes"
 	"io"
+	"mime/multipart"
 	"net/http"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/pkkummermo/govalin"
+	"github.com/pkkummermo/govalin/internal/http/contenttypes"
+	"github.com/pkkummermo/govalin/internal/http/headers"
 )
+
+// bodyTooLargeResponse is the response govalin writes when a request body
+// exceeds the configured max body read size.
+const bodyTooLargeResponse = `{"title":"Payload too large","status":413,` +
+	`"type":"https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413",` +
+	`"details":[{"field":"body","reason":"Request body exceeds the maximum allowed size"}]}`
 
 // newTestApp creates an app with logs disabled to keep test output clean,
 // optionally applying further config on top.
@@ -35,4 +47,44 @@ func readBody(t *testing.T, response *http.Response) string {
 	}
 
 	return string(data)
+}
+
+// urlEncodedRequest builds a POST carrying an application/x-www-form-urlencoded body.
+func urlEncodedRequest(t *testing.T, path string, values url.Values) *http.Request {
+	t.Helper()
+
+	request, err := http.NewRequest(http.MethodPost, path, strings.NewReader(values.Encode()))
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	request.Header.Set(headers.ContentType, contenttypes.ApplicationFormURLEncoded)
+
+	return request
+}
+
+// multipartRequest builds a POST carrying a single uploaded file.
+func multipartRequest(t *testing.T, path string, field string, content string) *http.Request {
+	t.Helper()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+
+	filePart, err := writer.CreateFormFile(field, "upload.txt")
+	if err != nil {
+		t.Fatalf("failed to create form file: %v", err)
+	}
+	if _, err = filePart.Write([]byte(content)); err != nil {
+		t.Fatalf("failed to write form file: %v", err)
+	}
+	if err = writer.Close(); err != nil {
+		t.Fatalf("failed to close multipart writer: %v", err)
+	}
+
+	request, err := http.NewRequest(http.MethodPost, path, &body)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	request.Header.Set(headers.ContentType, writer.FormDataContentType())
+
+	return request
 }


### PR DESCRIPTION
Follow-up to #76, which deliberately left the form paths alone.

## Why

`ServerMaxBodyReadSize` documents itself as "the max read size to accept from POST requests ... to control DDoS attacks using big body sizes", but only `readBody` ever honoured it:

1. **The limit was bypassed for every form POST.** `parseForm` called `ParseForm`/`ParseMultipartForm` directly, so net/http's own 10MB allowance silently took over instead of the configured cap.
2. **Every upload was forced to disk.** `ParseMultipartForm(0)` gives a zero in-memory budget, so each part was written to a temp file before the handler saw it — and the on-disk copy was bounded by nothing at all. I verified this: under the old code a 20MB upload was accepted with no ceiling in play.

## What changed

Applying `maxBodyReadSize` to every body shape doesn't work — a 4096 default would reject every file upload. So the limits split by what they actually bound:

| Option | Default | Bounds |
|---|---|---|
| `ServerMaxBodyReadSize` (existing) | 4096 | JSON/raw bodies **and URL-encoded forms** |
| `ServerMaxMultipartSize` (new) | 128 MiB | total multipart body size |
| `ServerMaxMultipartMemory` (new) | 32 MiB (matches net/http) | in-memory budget before parts spill to disk |

Note the 128 MiB multipart ceiling is a **tightening** — the previous behaviour had no total cap on what got written to disk.

Both paths now share one `limitBody` helper. It rejects a body whose declared `Content-Length` already exceeds the limit *before* reading a byte, and only falls back to `http.MaxBytesReader` otherwise. That pre-check matters: tripping `MaxBytesReader` makes net/http half-close and linger 500ms to avoid RSTing the client, so a body barely over the limit would otherwise cost a connection teardown.

**Two further faults found while writing coverage:**

- `File`/`Files` **nil-dereferenced** `req.MultipartForm` when called on a URL-encoded form — a hard panic, reproduced and now fixed via a `multipartForm()` accessor returning a 400.
- A form parsed *after* the body had already been read was reported as an empty form rather than an error, since `ParseForm` sees a drained body as EOF.

## Behaviour changes

**Breaking, both called out in the commit and ADR:**

- URL-encoded forms larger than `ServerMaxBodyReadSize` (default 4096) are now rejected; they previously got 10MB. Apps posting large forms must raise the limit.
- Oversized forms report **413** rather than a generic 400 "Invalid form data".

## Tests

`FormParams`, `File` and `Files` had **no coverage at all** before this. Seven new tests, including `TestMultipartFormMemoryBudget`, which type-asserts the opened part against `*os.File` and passes both ways — proving the old `(0)` really was forcing uploads to disk and that the new default keeps them in memory.

`gofmt`, `go vet`, `golangci-lint` (0 issues) and `go test -race -count=1 ./...` all pass.

## Docs

ADR [0005](docs/adr/0005-bounded-request-body-and-form-limits.md) records the decision, the four rejected alternatives, and the consequences. `CONTEXT.md` gains four terms — the size-cap vs. memory-budget distinction is exactly what the code otherwise needs a cross-reference comment to keep straight.

## Known interaction

Rejecting an oversized body with **no** declared `Content-Length` (chunked) still trips `MaxBytesReader`, so that connection holds for net/http's 500ms linger. The default `ServerShutdownTimeout` of 200ms is shorter than that window, so a shutdown immediately afterwards reports a timeout. Documented in the ADR; raising the default is a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
