### PR TITLE
fix(security): confine static serving to an os.Root and bound logged request values

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -176,8 +176,8 @@ comparing cleaned path strings.
 _Avoid_: prefix-comparison containment, cleaned-path-as-proof, stat-then-open resolution
 
 **Request-controlled value**:
-A value the client alone decides — request path, `User-Agent`, inbound `X-Govalin-Id`. Unbounded in
-length and unconstrained in content until govalin bounds it.
+A value the client alone decides — request path, `User-Agent`. Unbounded in length and unconstrained
+in content until govalin bounds it.
 _Avoid_: "it's just a header", trusting net/http to have filtered it
 
 **Log-safe value**:
@@ -186,11 +186,11 @@ bounded, and truncation marked so a cut value is never read as what the client s
 govalin, never assumed of the sink, because `slog.Default()` may be a text handler on a terminal.
 _Avoid_: verbatim header logging, sink-dependent escaping, silent truncation
 
-**Trusted correlation ID**:
-An inbound `X-Govalin-Id` adopted as the call ID only when it is a bounded, printable, whitespace-free
-token; anything else is replaced by a generated UUID. It is an identity echoed into every record for
-the request, so it is held to a stricter rule than a **Log-safe value**.
-_Avoid_: client-chosen ID adopted as-is, rejecting the request over a malformed header
+**Correlation ID**:
+The call ID, taken verbatim from an inbound `X-Govalin-Id` when the caller sends one and generated
+otherwise. It is deliberately *not* a **Log-safe value**: a caller propagates its own ID so it can
+find the request in govalin's log, and appearing verbatim in every record is the point of having one.
+_Avoid_: sanitizing the ID for the log, framework-imposed ID formats that break propagation
 
 ## Relationships
 
@@ -227,7 +227,7 @@ _Avoid_: client-chosen ID adopted as-is, rejecting the request over a malformed 
 - **Declared-length rejection** is the first enforcement step for every limit, with the limiter as the fallback for bodies of unknown length
 - **Root-confined static access** replaces path-string containment: the static mount is a resource the OS confines, not a prefix the framework checks
 - A **Request-controlled value** reaching a log becomes a **Log-safe value** first; there is no path from a header to a log sink that skips it
-- A **Trusted correlation ID** is the one **Request-controlled value** govalin may adopt as an identity, and only after it passes the token rule
+- The **Correlation ID** is the deliberate exception: client-chosen and logged verbatim, because propagating it is the feature
 
 ## Example dialogue
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -181,10 +181,11 @@ in content until govalin bounds it.
 _Avoid_: "it's just a header", trusting net/http to have filtered it
 
 **Log-safe value**:
-A **Request-controlled value** made fit to write to a log sink: control characters dropped, length
-bounded, and truncation marked so a cut value is never read as what the client sent. Applied by
-govalin, never assumed of the sink, because `slog.Default()` may be a text handler on a terminal.
-_Avoid_: verbatim header logging, sink-dependent escaping, silent truncation
+A **Request-controlled value** made fit to write to a log sink: length bounded, truncation marked so
+a cut value is never read as what the client sent, control characters dropped. The bound is the
+substance — no sink provides one; the scrub is defence in depth, since both standard `slog` handlers
+already escape control characters.
+_Avoid_: unbounded client values in a log line, silent truncation
 
 **Correlation ID**:
 The call ID, taken verbatim from an inbound `X-Govalin-Id` when the caller sends one and generated

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -169,6 +169,29 @@ _Avoid_: read-then-discard, limiter-only enforcement
 A non-fatal log emitted when an auxiliary runtime operation fails (e.g. mDNS registration/broadcast) must state what went wrong and what the user can do to fix it — not merely that an operation failed. Misconfiguration, by contrast, is caught early and is fatal.
 _Avoid_: "failed to start/configure" with no cause or remedy, silent runtime degradation
 
+**Root-confined static access**:
+Every file read below a static mount goes through an `os.Root` opened on the configured directory, so
+a name that leaves that directory — including through a symlink — is refused by the OS rather than by
+comparing cleaned path strings.
+_Avoid_: prefix-comparison containment, cleaned-path-as-proof, stat-then-open resolution
+
+**Request-controlled value**:
+A value the client alone decides — request path, `User-Agent`, inbound `X-Govalin-Id`. Unbounded in
+length and unconstrained in content until govalin bounds it.
+_Avoid_: "it's just a header", trusting net/http to have filtered it
+
+**Log-safe value**:
+A **Request-controlled value** made fit to write to a log sink: control characters dropped, length
+bounded, and truncation marked so a cut value is never read as what the client sent. Applied by
+govalin, never assumed of the sink, because `slog.Default()` may be a text handler on a terminal.
+_Avoid_: verbatim header logging, sink-dependent escaping, silent truncation
+
+**Trusted correlation ID**:
+An inbound `X-Govalin-Id` adopted as the call ID only when it is a bounded, printable, whitespace-free
+token; anything else is replaced by a generated UUID. It is an identity echoed into every record for
+the request, so it is held to a stricter rule than a **Log-safe value**.
+_Avoid_: client-chosen ID adopted as-is, rejecting the request over a malformed header
+
 ## Relationships
 
 - A **Race-clean build** is a required outcome of the **Stability gate**
@@ -202,6 +225,9 @@ _Avoid_: "failed to start/configure" with no cause or remedy, silent runtime deg
 - The **Plugin complexity boundary** does not exclude test tooling from the core module: a test package adds no dependency cost to consumers who never import it
 - The **Body size limit** and the **Multipart size limit** bound what the server accepts; the **Multipart memory budget** bounds only where an accepted upload is stored
 - **Declared-length rejection** is the first enforcement step for every limit, with the limiter as the fallback for bodies of unknown length
+- **Root-confined static access** replaces path-string containment: the static mount is a resource the OS confines, not a prefix the framework checks
+- A **Request-controlled value** reaching a log becomes a **Log-safe value** first; there is no path from a header to a log sink that skips it
+- A **Trusted correlation ID** is the one **Request-controlled value** govalin may adopt as an identity, and only after it passes the token rule
 
 ## Example dialogue
 

--- a/access_log_test.go
+++ b/access_log_test.go
@@ -162,9 +162,8 @@ func TestAccessLogNotFoundIsLogged(t *testing.T) {
 }
 
 // TestAccessLogSanitizesRequestDerivedValues covers the access log recording
-// values a client controls: the client must not be able to break a record into
-// two, drive terminal escape sequences through whoever reads the log, or decide
-// how many bytes one request costs the log sink.
+// values a client controls: nothing else caps them, so a request must not get
+// to decide how many bytes its log line costs.
 func TestAccessLogSanitizesRequestDerivedValues(t *testing.T) {
 	var buf syncBuffer
 	app := newAccessLogApp(true, func(app *govalin.App) {

--- a/access_log_test.go
+++ b/access_log_test.go
@@ -161,6 +161,50 @@ func TestAccessLogNotFoundIsLogged(t *testing.T) {
 	})
 }
 
+// TestAccessLogSanitizesRequestDerivedValues covers the access log recording
+// values a client controls: the client must not be able to break a record into
+// two, drive terminal escape sequences through whoever reads the log, or decide
+// how many bytes one request costs the log sink.
+func TestAccessLogSanitizesRequestDerivedValues(t *testing.T) {
+	var buf syncBuffer
+	app := newAccessLogApp(true, func(app *govalin.App) {
+		app.Get("/test", func(call *govalin.Call) { call.Text("govalin") })
+	})
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		defer captureAccessLog(&buf)()
+
+		req, err := http.NewRequest(http.MethodGet, "/test", nil)
+		assert.Nil(t, err)
+		// A tab is the only control character net/http will put on the wire, and
+		// it is enough to show control characters are dropped rather than logged.
+		req.Header.Set("User-Agent", "evil\tagent"+strings.Repeat("a", 1000))
+		response := client.Do(req)
+		_ = readBody(t, response)
+		time.Sleep(accessLogSettleTime)
+
+		log := buf.String()
+
+		assert.Contains(
+			t,
+			log,
+			"evilagent",
+			"Control characters should be dropped from the logged user agent",
+		)
+		assert.NotContains(
+			t,
+			log,
+			strings.Repeat("a", 1000),
+			"An oversized user agent should be truncated before it reaches the log",
+		)
+		assert.Contains(
+			t,
+			log,
+			"…",
+			"A truncated value should be marked as truncated",
+		)
+	})
+}
+
 // TestAccessLogDisabledLogsNothing ensures that when access logging is disabled
 // nothing is logged, including the short-circuit before-handler path that used
 // to log unconditionally regardless of the config flag.

--- a/call.go
+++ b/call.go
@@ -54,13 +54,13 @@ type Call struct {
 }
 
 func newCallFromRequest(w http.ResponseWriter, req *http.Request, config *Config, pathParams map[string]string) Call {
-	govalinIDHeader := req.Header[http.CanonicalHeaderKey("x-govalin-id")]
-
-	var uniqueID string
-	if govalinIDHeader == nil {
+	// The correlation ID is attacker-controlled and ends up in every log record
+	// for the request, so an inbound one is adopted only when it looks like an
+	// ID. Anything else is replaced by a generated one rather than rejected, so
+	// a malformed header never fails an otherwise valid request.
+	uniqueID := req.Header.Get(headers.XGovalinID)
+	if !isValidCorrelationID(uniqueID) {
 		uniqueID = uuid.New().String()
-	} else {
-		uniqueID = govalinIDHeader[0]
 	}
 
 	call := Call{

--- a/call.go
+++ b/call.go
@@ -54,13 +54,13 @@ type Call struct {
 }
 
 func newCallFromRequest(w http.ResponseWriter, req *http.Request, config *Config, pathParams map[string]string) Call {
-	// The correlation ID is attacker-controlled and ends up in every log record
-	// for the request, so an inbound one is adopted only when it looks like an
-	// ID. Anything else is replaced by a generated one rather than rejected, so
-	// a malformed header never fails an otherwise valid request.
-	uniqueID := req.Header.Get(headers.XGovalinID)
-	if !isValidCorrelationID(uniqueID) {
+	govalinIDHeader := req.Header[headers.XGovalinID]
+
+	var uniqueID string
+	if govalinIDHeader == nil {
 		uniqueID = uuid.New().String()
+	} else {
+		uniqueID = govalinIDHeader[0]
 	}
 
 	call := Call{

--- a/call_test.go
+++ b/call_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/google/uuid"
 	"github.com/pkkummermo/govalin"
 	"github.com/pkkummermo/govalin/govalintest"
 	"github.com/pkkummermo/govalin/internal/http/headers"
@@ -400,48 +399,6 @@ func TestRequestID(t *testing.T) {
 			"govalin",
 			"Should reuse given ID",
 		)
-	})
-}
-
-// TestRequestIDRejectsHostileHeader covers the correlation ID being echoed into
-// every log record for the request: a client must not be able to decide how long
-// that value is, or to smuggle separators into it.
-func TestRequestIDRejectsHostileHeader(t *testing.T) {
-	app := newTestApp()
-	app.Get("/govalin", func(call *govalin.Call) {
-		call.Text(call.ID())
-	})
-
-	govalintest.Test(t, app, func(client *govalintest.Client) {
-		hostileIDs := map[string]string{
-			"oversized":   strings.Repeat("a", 129),
-			"whitespace":  "govalin id",
-			"non-ascii":   "govalin-ïd",
-			"empty value": "",
-		}
-
-		for name, hostileID := range hostileIDs {
-			req, err := http.NewRequest(http.MethodGet, "/govalin", nil)
-			assert.Nil(t, err)
-			req.Header.Set(headers.XGovalinID, hostileID)
-
-			id := readBody(t, client.Do(req))
-
-			assert.NotEqual(
-				t,
-				hostileID,
-				id,
-				"Should not adopt an %s correlation ID",
-				name,
-			)
-			assert.Len(
-				t,
-				id,
-				len(uuid.NewString()),
-				"Should fall back to a generated ID for an %s correlation ID",
-				name,
-			)
-		}
 	})
 }
 

--- a/call_test.go
+++ b/call_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/pkkummermo/govalin"
 	"github.com/pkkummermo/govalin/govalintest"
 	"github.com/pkkummermo/govalin/internal/http/headers"
@@ -399,6 +400,48 @@ func TestRequestID(t *testing.T) {
 			"govalin",
 			"Should reuse given ID",
 		)
+	})
+}
+
+// TestRequestIDRejectsHostileHeader covers the correlation ID being echoed into
+// every log record for the request: a client must not be able to decide how long
+// that value is, or to smuggle separators into it.
+func TestRequestIDRejectsHostileHeader(t *testing.T) {
+	app := newTestApp()
+	app.Get("/govalin", func(call *govalin.Call) {
+		call.Text(call.ID())
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		hostileIDs := map[string]string{
+			"oversized":   strings.Repeat("a", 129),
+			"whitespace":  "govalin id",
+			"non-ascii":   "govalin-ïd",
+			"empty value": "",
+		}
+
+		for name, hostileID := range hostileIDs {
+			req, err := http.NewRequest(http.MethodGet, "/govalin", nil)
+			assert.Nil(t, err)
+			req.Header.Set(headers.XGovalinID, hostileID)
+
+			id := readBody(t, client.Do(req))
+
+			assert.NotEqual(
+				t,
+				hostileID,
+				id,
+				"Should not adopt an %s correlation ID",
+				name,
+			)
+			assert.Len(
+				t,
+				id,
+				len(uuid.NewString()),
+				"Should fall back to a generated ID for an %s correlation ID",
+				name,
+			)
+		}
 	})
 }
 

--- a/docs/adr/0006-root-confined-static-serving-and-log-safe-request-values.md
+++ b/docs/adr/0006-root-confined-static-serving-and-log-safe-request-values.md
@@ -37,22 +37,41 @@ Two behaviours follow from that and are deliberate:
 ### Values a client controls are bounded and scrubbed before they are logged
 
 The access log recorded the request path and `User-Agent` verbatim. Both are chosen by the client and
-both are unbounded: a request could decide how many bytes one log line costs, and — depending on the
-sink — smuggle control characters that break a record in two or carry terminal escape sequences to
-whoever reads the log.
+neither is capped by anything else, so a request decided how many bytes its log line cost — up to
+`MaxHeaderBytes` (1MB by default) for the user agent, and as much again for the path.
 
-`logSafeValue` drops control characters and bounds the value at 256 characters, marking a truncated
-value with `…` so it is never mistaken for what the client actually sent. The bound counts characters
-rather than bytes, so multi-byte text is not cut mid-rune.
+`logSafeValue` bounds the value at 256 characters, marking a truncated value with `…` so it is never
+mistaken for what the client actually sent. The bound counts characters rather than bytes, so
+multi-byte text is not cut mid-rune.
+
+It also drops control characters, but as defence in depth rather than as the fix for a live hole.
+Measured against the real stack:
+
+- Control bytes in a *header* value never arrive: net/http answers **400** to a request carrying
+  `ESC`, `NUL` or `DEL` in a header, before any handler or log call runs. Only tab, and `\r\n `
+  continuation folded to a space, get through.
+- Control bytes in a *path* do arrive, because percent-encoding survives the request-line check and
+  `url.Parse` decodes it — `/x%00`, `/x%1b[31m` and `/x%0a` all reach the handler.
+- `slog`'s own text and JSON handlers then escape them: a newline is written `\n`, an escape byte
+  `\x1b` (text) or `\u001b` (JSON). Neither can break a record or reach a terminal raw.
+
+So scrubbing guards only the case of a handler that does not escape. It is kept because it is nearly
+free and govalin does not choose the handler it logs through, not because the standard ones leak.
 
 ### The logged call ID is not a finding
 
 The third alert flags the call ID on the same log call, because it originates in the inbound
 `X-Govalin-Id` header. That is the feature, not a leak: the header exists so a caller can propagate
 its own correlation ID, and appearing in every record for the request is the entire point of having
-one. Nothing sensitive is disclosed — the client reads back an identifier it chose itself. The ID is
-therefore logged as-is, and the alert is dismissed as a false positive rather than answered with
-code.
+one. Nothing sensitive is disclosed — the client reads back an identifier it chose itself.
+
+Nor is there a payload to smuggle through it. A header value carrying `ESC`, `NUL` or `DEL` is
+answered 400 by net/http before govalin sees it; what does get through (tab, folded continuation
+lines) is escaped by `slog`. The only thing an inbound ID can still do is be long, which is a
+log-volume question and not what the alert is about.
+
+The ID is therefore logged as sent, and the alert is dismissed as a false positive rather than
+answered with code.
 
 ## Considered options
 
@@ -70,9 +89,9 @@ code.
   Rejected; the alert is the thing that is wrong, not the behaviour.
 - **Dropping user agent and path from the access log** — removes the tainted values outright, and with
   them the reason anyone reads an access log. Rejected.
-- **Leaving sanitization to the log sink** — correct for a JSON handler, which escapes control
-  characters, but govalin does not choose its own sink: `slog.Default()` may be a text handler writing
-  to a terminal. Rejected as an assumption the framework cannot make.
+- **Leaving control characters to the log sink** — accepted, in effect: both standard `slog` handlers
+  escape them, so the scrub in `logSafeValue` is redundant with them and is kept only for a custom
+  handler that does not. It is the *length* bound that no sink provides.
 
 ## Consequences
 

--- a/docs/adr/0006-root-confined-static-serving-and-log-safe-request-values.md
+++ b/docs/adr/0006-root-confined-static-serving-and-log-safe-request-values.md
@@ -1,0 +1,83 @@
+# Root-confined static serving and log-safe request values
+
+## Status
+
+accepted
+
+## Context and decision
+
+Three open CodeQL alerts pointed at the two places where a request decides what the framework
+touches: the static file handler (`go/path-injection`) and the access log (`go/clear-text-logging`,
+twice). They are treated as one class — *request-controlled values reaching a resource the request
+should not get to name* — and fixed together.
+
+### Static serving is confined by the OS, not by string comparison
+
+`handle` resolved the request path against the static directory and then compared the cleaned
+absolute result against the cleaned absolute root. That rejects `../` traversal, but path arithmetic
+only describes names, not what they resolve to: a symlink inside the static directory is contained as
+a *path* while pointing anywhere on the filesystem, so it passed the check and was then stat'd and
+served.
+
+Static serving now opens the configured directory as an `os.Root` and does every read through it. The
+kernel refuses any name that leaves the root, including through a symlink, and the containment no
+longer depends on getting string comparison right on every platform. The two branches also collapse:
+an `os.Root.FS()` is an `fs.FS`, so the on-disk and embedded cases share one stat and one file server
+instead of each having their own.
+
+Two behaviours follow from that and are deliberate:
+
+- A name that fails to resolve is answered **404 directly**, rather than being handed on to
+  `http.FileServer`. A name that escapes the root is not a *missing* file to the file server, which
+  would answer 500 and thereby confirm that something is there.
+- A mount whose directory cannot be opened is a **500** with an actionable log line, not a 404 for
+  every request. A static mount pointing at a directory that is not there is a misconfiguration, and
+  reporting it as "no such file" hides it.
+
+### Values a client controls are bounded and scrubbed before they are logged
+
+The access log recorded the request path and `User-Agent` verbatim, and the call ID verbatim from the
+inbound `X-Govalin-Id` header. All three are chosen by the client, and all three are unbounded: a
+request could decide how many bytes one log line costs, and — depending on the sink — smuggle control
+characters that break a record in two or carry terminal escape sequences to whoever reads the log.
+
+`logSafeValue` drops control characters and bounds the value at 256 characters, marking a truncated
+value with `…` so it is never mistaken for what the client actually sent. The bound counts characters
+rather than bytes, so multi-byte text is not cut mid-rune.
+
+The correlation ID gets a stricter rule, because it is an *identity* and not just a logged value: an
+inbound `X-Govalin-Id` is adopted only when it is a bounded (≤128), printable, whitespace-free token.
+Anything else is replaced by a generated UUID rather than rejected, so a malformed header never fails
+an otherwise valid request.
+
+## Considered options
+
+- **`os.Root` confinement (chosen)** — see above.
+- **Keeping the prefix check and adding `filepath.EvalSymlinks`** — closes the symlink hole with no
+  new API, but re-introduces the same time-of-check/time-of-use gap the check already had: the path
+  is resolved, then opened separately. Rejected.
+- **Relying on `http.Dir`/`http.FileServer` alone** — the file server does clean the request path, so
+  it was never the leak; the `os.Stat` ahead of it was, as an existence oracle for files outside the
+  root. Dropping the stat would lose SPA-mode fallback, which depends on knowing whether the file
+  exists. Rejected.
+- **Rejecting a hostile `X-Govalin-Id` with 400** — surfaces the bad header loudly, but makes a header
+  that most clients never set into a way to fail a valid request. Rejected in favour of falling back
+  to a generated ID.
+- **Dropping user agent and path from the access log** — removes the tainted values outright, and with
+  them the reason anyone reads an access log. Rejected.
+- **Leaving sanitization to the log sink** — correct for a JSON handler, which escapes control
+  characters, but govalin does not choose its own sink: `slog.Default()` may be a text handler writing
+  to a terminal. Rejected as an assumption the framework cannot make.
+
+## Consequences
+
+- **Breaking**: a static mount whose directory is missing or unreadable now answers 500 instead of 404.
+- **Breaking**: an `X-Govalin-Id` longer than 128 characters, or containing whitespace, control
+  characters or non-ASCII bytes, is no longer echoed as the call ID; a generated UUID is used instead.
+  Callers propagating a correlation ID need one that fits the rule — a UUID does.
+- Static files reachable only through a symlink out of the static directory are no longer served. A
+  deployment that relied on symlinking content in from elsewhere must move or bind-mount it instead.
+- Access log values are capped at 256 characters, so a very long path or user agent appears truncated
+  with a trailing `…`.
+- On-disk and embedded static mounts now run the same code path, so behaviour that used to differ
+  between them (status set before the file server ran) is the same for both.

--- a/docs/adr/0006-root-confined-static-serving-and-log-safe-request-values.md
+++ b/docs/adr/0006-root-confined-static-serving-and-log-safe-request-values.md
@@ -8,8 +8,8 @@ accepted
 
 Three open CodeQL alerts pointed at the two places where a request decides what the framework
 touches: the static file handler (`go/path-injection`) and the access log (`go/clear-text-logging`,
-twice). They are treated as one class — *request-controlled values reaching a resource the request
-should not get to name* — and fixed together.
+twice). Two describe a real weakness and are fixed here; the third does not, and is recorded below as
+a false positive rather than designed around.
 
 ### Static serving is confined by the OS, not by string comparison
 
@@ -36,19 +36,23 @@ Two behaviours follow from that and are deliberate:
 
 ### Values a client controls are bounded and scrubbed before they are logged
 
-The access log recorded the request path and `User-Agent` verbatim, and the call ID verbatim from the
-inbound `X-Govalin-Id` header. All three are chosen by the client, and all three are unbounded: a
-request could decide how many bytes one log line costs, and — depending on the sink — smuggle control
-characters that break a record in two or carry terminal escape sequences to whoever reads the log.
+The access log recorded the request path and `User-Agent` verbatim. Both are chosen by the client and
+both are unbounded: a request could decide how many bytes one log line costs, and — depending on the
+sink — smuggle control characters that break a record in two or carry terminal escape sequences to
+whoever reads the log.
 
 `logSafeValue` drops control characters and bounds the value at 256 characters, marking a truncated
 value with `…` so it is never mistaken for what the client actually sent. The bound counts characters
 rather than bytes, so multi-byte text is not cut mid-rune.
 
-The correlation ID gets a stricter rule, because it is an *identity* and not just a logged value: an
-inbound `X-Govalin-Id` is adopted only when it is a bounded (≤128), printable, whitespace-free token.
-Anything else is replaced by a generated UUID rather than rejected, so a malformed header never fails
-an otherwise valid request.
+### The logged call ID is not a finding
+
+The third alert flags the call ID on the same log call, because it originates in the inbound
+`X-Govalin-Id` header. That is the feature, not a leak: the header exists so a caller can propagate
+its own correlation ID, and appearing in every record for the request is the entire point of having
+one. Nothing sensitive is disclosed — the client reads back an identifier it chose itself. The ID is
+therefore logged as-is, and the alert is dismissed as a false positive rather than answered with
+code.
 
 ## Considered options
 
@@ -60,9 +64,10 @@ an otherwise valid request.
   it was never the leak; the `os.Stat` ahead of it was, as an existence oracle for files outside the
   root. Dropping the stat would lose SPA-mode fallback, which depends on knowing whether the file
   exists. Rejected.
-- **Rejecting a hostile `X-Govalin-Id` with 400** — surfaces the bad header loudly, but makes a header
-  that most clients never set into a way to fail a valid request. Rejected in favour of falling back
-  to a generated ID.
+- **Constraining the inbound `X-Govalin-Id` to a bounded printable token, falling back to a generated
+  UUID** — would silence the third alert, at the cost of the propagation the header exists for: a
+  caller's own correlation ID no longer survives if it does not match govalin's idea of a token.
+  Rejected; the alert is the thing that is wrong, not the behaviour.
 - **Dropping user agent and path from the access log** — removes the tainted values outright, and with
   them the reason anyone reads an access log. Rejected.
 - **Leaving sanitization to the log sink** — correct for a JSON handler, which escapes control
@@ -72,9 +77,9 @@ an otherwise valid request.
 ## Consequences
 
 - **Breaking**: a static mount whose directory is missing or unreadable now answers 500 instead of 404.
-- **Breaking**: an `X-Govalin-Id` longer than 128 characters, or containing whitespace, control
-  characters or non-ASCII bytes, is no longer echoed as the call ID; a generated UUID is used instead.
-  Callers propagating a correlation ID need one that fits the rule — a UUID does.
+- An inbound `X-Govalin-Id` is still adopted verbatim as the call ID and still logged verbatim, so a
+  client can put an arbitrarily long value in every log record for its request. That is accepted:
+  bounding it would break correlation-ID propagation, which is what the header is for.
 - Static files reachable only through a symlink out of the static directory are no longer served. A
   deployment that relied on symlinking content in from elsewhere must move or bind-mount it instead.
 - Access log values are capped at 256 characters, so a very long path or user agent appears truncated

--- a/internal/http/headers/headers.go
+++ b/internal/http/headers/headers.go
@@ -73,6 +73,7 @@ const (
 	XForwardedFor                 = "X-Forwarded-For"
 	XForwardedProto               = "X-Forwarded-Proto"
 	XFrameOptions                 = "X-Frame-Options"
+	XGovalinID                    = "X-Govalin-Id"
 	XHttpMethodOverride           = "X-HTTP-Method-Override"
 	XPermittedCrossDomainPolicies = "X-Permitted-Cross-Domain-Policies"
 )

--- a/logsafe.go
+++ b/logsafe.go
@@ -1,0 +1,64 @@
+package govalin
+
+import (
+	"strings"
+	"unicode"
+)
+
+const (
+	// maxLoggedValueLength bounds a request-derived value in the access log. Long
+	// enough for a realistic user agent or path, short enough that a request
+	// cannot decide how much a log line costs.
+	maxLoggedValueLength = 256
+
+	// maxCorrelationIDLength bounds an inbound X-Govalin-Id.
+	maxCorrelationIDLength = 128
+
+	// truncationMarker is appended to a value that was cut short, so a truncated
+	// value is never mistaken for the value the client actually sent.
+	truncationMarker = "…"
+)
+
+// logSafeValue makes a request-derived value safe to write to a log sink:
+// control characters (which forge line breaks and drive terminal escape
+// sequences) are dropped and the result is bounded by maxLoggedValueLength.
+// Ranging over the string also folds invalid UTF-8 into U+FFFD.
+func logSafeValue(value string) string {
+	var builder strings.Builder
+
+	length := 0
+
+	for _, char := range value {
+		if unicode.IsControl(char) {
+			continue
+		}
+
+		if length == maxLoggedValueLength {
+			builder.WriteString(truncationMarker)
+			break
+		}
+
+		builder.WriteRune(char)
+		length++
+	}
+
+	return builder.String()
+}
+
+// isValidCorrelationID reports whether a client-supplied X-Govalin-Id may be
+// adopted as the call ID. The ID is echoed into every log record for the
+// request, so only a bounded, printable, whitespace-free token is trusted;
+// anything else is discarded in favour of a generated one.
+func isValidCorrelationID(id string) bool {
+	if id == "" || len(id) > maxCorrelationIDLength {
+		return false
+	}
+
+	for _, char := range []byte(id) {
+		if char <= ' ' || char > '~' {
+			return false
+		}
+	}
+
+	return true
+}

--- a/logsafe.go
+++ b/logsafe.go
@@ -16,10 +16,11 @@ const (
 	truncationMarker = "…"
 )
 
-// logSafeValue makes a request-derived value safe to write to a log sink:
-// control characters (which forge line breaks and drive terminal escape
-// sequences) are dropped and the result is bounded by maxLoggedValueLength.
-// Ranging over the string also folds invalid UTF-8 into U+FFFD.
+// logSafeValue bounds a request-derived value and drops control characters,
+// marking truncation so a cut value is not read as what the client sent. The
+// bound is the point — nothing else caps a client-chosen path or user agent.
+// Scrubbing is defence in depth: slog's own handlers escape control characters,
+// but a percent-encoded path does decode into raw ones.
 func logSafeValue(value string) string {
 	var builder strings.Builder
 

--- a/logsafe.go
+++ b/logsafe.go
@@ -11,9 +11,6 @@ const (
 	// cannot decide how much a log line costs.
 	maxLoggedValueLength = 256
 
-	// maxCorrelationIDLength bounds an inbound X-Govalin-Id.
-	maxCorrelationIDLength = 128
-
 	// truncationMarker is appended to a value that was cut short, so a truncated
 	// value is never mistaken for the value the client actually sent.
 	truncationMarker = "…"
@@ -43,22 +40,4 @@ func logSafeValue(value string) string {
 	}
 
 	return builder.String()
-}
-
-// isValidCorrelationID reports whether a client-supplied X-Govalin-Id may be
-// adopted as the call ID. The ID is echoed into every log record for the
-// request, so only a bounded, printable, whitespace-free token is trusted;
-// anything else is discarded in favour of a generated one.
-func isValidCorrelationID(id string) bool {
-	if id == "" || len(id) > maxCorrelationIDLength {
-		return false
-	}
-
-	for _, char := range []byte(id) {
-		if char <= ' ' || char > '~' {
-			return false
-		}
-	}
-
-	return true
 }

--- a/logsafe_test.go
+++ b/logsafe_test.go
@@ -1,0 +1,76 @@
+package govalin
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// These helpers guard values a client fully controls, so they are tested
+// directly rather than only through the server: net/http rejects some hostile
+// header values before they ever reach a handler, and the checks must hold
+// regardless of what that layer happens to filter today.
+
+func TestLogSafeValue(t *testing.T) {
+	assert.Equal(
+		t,
+		"govalin",
+		logSafeValue("govalin"),
+		"An ordinary value should pass through unchanged",
+	)
+	assert.Equal(
+		t,
+		"forgedmsg=evil",
+		logSafeValue("forged\r\nmsg=evil"),
+		"Line breaks used to forge a second record should be dropped",
+	)
+	assert.Equal(
+		t,
+		"[0m",
+		logSafeValue("\x1b[0m"),
+		"Terminal escape sequences should lose their control character",
+	)
+	assert.Equal(
+		t,
+		strings.Repeat("a", maxLoggedValueLength)+truncationMarker,
+		logSafeValue(strings.Repeat("a", maxLoggedValueLength+1)),
+		"A value past the limit should be truncated and marked",
+	)
+	assert.Equal(
+		t,
+		strings.Repeat("a", maxLoggedValueLength),
+		logSafeValue(strings.Repeat("a", maxLoggedValueLength)),
+		"A value exactly at the limit should not be marked as truncated",
+	)
+	assert.Equal(
+		t,
+		"æøå",
+		logSafeValue("æøå"),
+		"The limit counts characters, so multi-byte text is not cut mid-rune",
+	)
+}
+
+func TestIsValidCorrelationID(t *testing.T) {
+	valid := []string{
+		"govalin",
+		"7f1c9f4e-1f6d-4f0a-9b3a-2c5f8e0d1a2b",
+		strings.Repeat("a", maxCorrelationIDLength),
+	}
+	for _, id := range valid {
+		assert.True(t, isValidCorrelationID(id), "%q should be accepted as a correlation ID", id)
+	}
+
+	invalid := []string{
+		"",
+		"govalin id",
+		"govalin\nid",
+		"govalin\tid",
+		"govalin\x00id",
+		"govalin-ïd",
+		strings.Repeat("a", maxCorrelationIDLength+1),
+	}
+	for _, id := range invalid {
+		assert.False(t, isValidCorrelationID(id), "%q should be rejected as a correlation ID", id)
+	}
+}

--- a/logsafe_test.go
+++ b/logsafe_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// These helpers guard values a client fully controls, so they are tested
-// directly rather than only through the server: net/http rejects some hostile
-// header values before they ever reach a handler, and the checks must hold
-// regardless of what that layer happens to filter today.
+// logSafeValue guards values a client fully controls, so it is tested directly
+// rather than only through the server: net/http rejects some hostile header
+// values before they ever reach a handler, and the check must hold regardless
+// of what that layer happens to filter today.
 
 func TestLogSafeValue(t *testing.T) {
 	assert.Equal(
@@ -49,28 +49,4 @@ func TestLogSafeValue(t *testing.T) {
 		logSafeValue("æøå"),
 		"The limit counts characters, so multi-byte text is not cut mid-rune",
 	)
-}
-
-func TestIsValidCorrelationID(t *testing.T) {
-	valid := []string{
-		"govalin",
-		"7f1c9f4e-1f6d-4f0a-9b3a-2c5f8e0d1a2b",
-		strings.Repeat("a", maxCorrelationIDLength),
-	}
-	for _, id := range valid {
-		assert.True(t, isValidCorrelationID(id), "%q should be accepted as a correlation ID", id)
-	}
-
-	invalid := []string{
-		"",
-		"govalin id",
-		"govalin\nid",
-		"govalin\tid",
-		"govalin\x00id",
-		"govalin-ïd",
-		strings.Repeat("a", maxCorrelationIDLength+1),
-	}
-	for _, id := range invalid {
-		assert.False(t, isValidCorrelationID(id), "%q should be rejected as a correlation ID", id)
-	}
 }

--- a/logsafe_test.go
+++ b/logsafe_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// logSafeValue guards values a client fully controls, so it is tested directly
-// rather than only through the server: net/http rejects some hostile header
-// values before they ever reach a handler, and the check must hold regardless
-// of what that layer happens to filter today.
+// logSafeValue is tested directly rather than only through the server, because
+// net/http answers 400 to a request carrying control bytes in a header and so
+// filters most hostile input before a handler ever sees it. The check must hold
+// on its own terms regardless of what that layer happens to reject today.
 
 func TestLogSafeValue(t *testing.T) {
 	assert.Equal(
@@ -23,7 +23,7 @@ func TestLogSafeValue(t *testing.T) {
 		t,
 		"forgedmsg=evil",
 		logSafeValue("forged\r\nmsg=evil"),
-		"Line breaks used to forge a second record should be dropped",
+		"Line breaks should be dropped rather than left for the sink to escape",
 	)
 	assert.Equal(
 		t,

--- a/server.go
+++ b/server.go
@@ -474,16 +474,18 @@ func (server *App) rootHandlerFunc(w http.ResponseWriter, req *http.Request) {
 }
 
 func (server *App) logAccessLog(call *Call, durationInMS float64) {
+	// Path and user agent come straight off the wire; bound and scrub them so a
+	// request cannot forge log records or decide how large a log line is.
 	slog.Info(
 		"incoming request",
 		slog.String("id", call.ID()),
 		slog.String("method", call.Method()),
 		slog.Float64("duration_in_ms", durationInMS),
-		slog.String("path", call.URL().Path),
+		slog.String("path", logSafeValue(call.URL().Path)),
 		slog.Int("status", call.status),
 		slog.String(
 			"user_agent",
-			call.UserAgent(),
+			logSafeValue(call.UserAgent()),
 		),
 	)
 }

--- a/server.go
+++ b/server.go
@@ -474,8 +474,9 @@ func (server *App) rootHandlerFunc(w http.ResponseWriter, req *http.Request) {
 }
 
 func (server *App) logAccessLog(call *Call, durationInMS float64) {
-	// Path and user agent come straight off the wire; bound and scrub them so a
-	// request cannot forge log records or decide how large a log line is.
+	// Path and user agent come straight off the wire and are capped by nothing
+	// else, so bound them rather than let a request decide how large a log line
+	// is. The call ID is deliberately logged as sent — see ADR 0006.
 	slog.Info(
 		"incoming request",
 		slog.String("id", call.ID()),

--- a/static.go
+++ b/static.go
@@ -75,64 +75,41 @@ Are you sure it exists on the given path: '%s'`, indexPath))
 	http.ServeFile(*call.Raw.W, call.Raw.Req, filepath.Join(config.staticPath, "index.html"))
 }
 
-// resolveWithinStaticRoot resolves requestPath against the static root directory
-// and verifies the result is contained within that root. It returns the
-// absolute, cleaned path and true when the path is safe, or false when the path
-// escapes the root (a path-traversal attempt) or cannot be resolved.
-func resolveWithinStaticRoot(staticRoot string, requestPath string) (string, bool) {
-	absRoot, rootErr := filepath.Abs(staticRoot)
-	if rootErr != nil {
-		return "", false
-	}
-
-	absPath, pathErr := filepath.Abs(filepath.Join(absRoot, requestPath))
-	if pathErr != nil {
-		return "", false
-	}
-
-	// The resolved path is safe only when it is the root itself or lives
-	// underneath it. Comparing against absRoot+separator avoids treating a
-	// sibling directory with a shared prefix (e.g. "/srv/static-evil" for a
-	// "/srv/static" root) as contained.
-	if absPath != absRoot && !strings.HasPrefix(absPath, absRoot+string(filepath.Separator)) {
-		return "", false
-	}
-
-	return absPath, true
-}
-
 func (config *StaticConfig) handle(call *Call) {
 	isFS := config.fsContent != nil
-	isStatic := config.fsContent == nil
-
-	path := call.URL().Path
 
 	// remove host path
-	path = strings.TrimPrefix(path, config.hostPath)
+	path := strings.TrimPrefix(call.URL().Path, config.hostPath)
 
-	if isStatic {
-		// Resolve the requested path within the static directory and verify the
-		// result stays inside it. This rejects path-traversal attempts (e.g.
-		// "/../../etc/passwd") that would otherwise let an attacker stat (and
-		// probe the existence of) or serve files outside the static root.
-		safePath, withinRoot := resolveWithinStaticRoot(config.staticPath, path)
-		if !withinRoot {
-			call.Status(http.StatusNotFound)
-			call.Text("404 page not found")
+	hostedFileSystem := config.fsContent
+
+	if !isFS {
+		// Every read below the mount goes through the root, so a traversal
+		// segment or a symlink pointing outside the static directory is refused
+		// by the OS instead of by string comparison on a cleaned path.
+		root, rootErr := os.OpenRoot(config.staticPath)
+		if rootErr != nil {
+			slog.Error(fmt.Sprintf(`Failed to open the configured static file folder.
+Are you sure it exists and is readable on the given path: '%s'`, config.staticPath))
+			call.Status(http.StatusInternalServerError)
+			call.Text("500 internal server error")
+
 			return
 		}
+		defer func() { _ = root.Close() }()
 
-		path = safePath
+		hostedFileSystem = root.FS()
+	}
+
+	// An fs.FS addresses entries relative to its root, and names the root
+	// directory itself "." rather than the empty string.
+	name := strings.TrimPrefix(path, "/")
+	if name == "" {
+		name = "."
 	}
 
 	// check whether a file exists at the given path
-	var statErr error
-
-	if isFS {
-		_, statErr = fs.Stat(config.fsContent, strings.TrimPrefix(path, "/"))
-	} else {
-		_, statErr = os.Stat(path)
-	}
+	_, statErr := fs.Stat(hostedFileSystem, name)
 
 	var pathErr *fs.PathError
 
@@ -152,7 +129,13 @@ func (config *StaticConfig) handle(call *Call) {
 
 	switch {
 	case isNotFoundError:
+		// Answer directly instead of handing an unresolvable name to the file
+		// server. A name that escapes the root is not a missing file to it, so it
+		// would answer 500 and thereby confirm that something is there.
 		call.Status(http.StatusNotFound)
+		call.Text("404 page not found")
+
+		return
 	case statErr != nil:
 		// if we got an error (that wasn't that the file doesn't exist) stating the
 		// file, return a 500 internal server error and stop
@@ -164,13 +147,7 @@ func (config *StaticConfig) handle(call *Call) {
 	}
 
 	// otherwise, use http.FileServer to serve the file system
-	var hostedFileSystem http.FileSystem
-	if isFS {
-		hostedFileSystem = http.FS(config.fsContent)
-	} else {
-		hostedFileSystem = http.Dir(config.staticPath)
-	}
-
+	//
 	// http.FileServer takes over the raw writer and writes the response header
 	// itself. Bypass the lifecycle (same contract as HTTPServe) so the buffered
 	// status isn't flushed a second time, which would trigger a superfluous
@@ -178,7 +155,7 @@ func (config *StaticConfig) handle(call *Call) {
 	call.bypassLifecycle = true
 	http.StripPrefix(
 		config.hostPath,
-		http.FileServer(hostedFileSystem),
+		http.FileServer(http.FS(hostedFileSystem)),
 	).ServeHTTP(*call.Raw.W, call.Raw.Req)
 }
 

--- a/static_test.go
+++ b/static_test.go
@@ -3,6 +3,8 @@ package govalin_test
 import (
 	"embed"
 	"io/fs"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/pkkummermo/govalin"
@@ -167,6 +169,79 @@ func TestStaticFolderPathTraversal(t *testing.T) {
 				attempt,
 			)
 		}
+	})
+}
+
+func TestStaticFolderSymlinkEscape(t *testing.T) {
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "secret.txt")
+	assert.Nil(t, os.WriteFile(secret, []byte("Govalin secret"), 0o600))
+
+	staticRoot := t.TempDir()
+	assert.Nil(t, os.WriteFile(
+		filepath.Join(staticRoot, "index.html"),
+		[]byte("Hello world"),
+		0o600,
+	))
+
+	// A symlink is contained by the static root as a *path*, so path arithmetic
+	// alone accepts it; only resolving it against the root shows it leaves.
+	assert.Nil(t, os.Symlink(secret, filepath.Join(staticRoot, "escape.txt")))
+	assert.Nil(t, os.Symlink(outside, filepath.Join(staticRoot, "escape-dir")))
+
+	app := newTestApp()
+	app.Static("/static", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithStaticPath(staticRoot)
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		escapes := []string{
+			"/static/escape.txt",
+			"/static/escape-dir/secret.txt",
+		}
+
+		for _, attempt := range escapes {
+			response := client.GetResponse(attempt)
+			body := readBody(t, response)
+
+			assert.Equal(
+				t,
+				404,
+				response.StatusCode,
+				"Symlink %q pointing outside the static root should not resolve",
+				attempt,
+			)
+			assert.NotContains(
+				t,
+				body,
+				"Govalin secret",
+				"Symlink %q must not leak contents of files outside the static root",
+				attempt,
+			)
+		}
+
+		assert.Contains(
+			t,
+			client.Get("/static/index.html"),
+			"Hello world",
+			"Files genuinely inside the static root should still be served",
+		)
+	})
+}
+
+func TestStaticFolderMissingRoot(t *testing.T) {
+	app := newTestApp()
+	app.Static("/static", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithStaticPath(filepath.Join(t.TempDir(), "does-not-exist"))
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		assert.Equal(
+			t,
+			500,
+			client.GetStatus("/static/index.html"),
+			"A static mount whose folder is missing is a misconfiguration, not a 404",
+		)
 	})
 }
 


### PR DESCRIPTION
Addresses the three open code-scanning alerts. One describes a real weakness, one is a hardening with a narrower justification than it first appeared, and one is a false positive that is dismissed rather than designed around.

| Alert | Rule | Outcome |
| --- | --- | --- |
| [#2](https://github.com/pkkummermo/govalin/security/code-scanning/2) | `go/path-injection` | **Fixed** — static serving confined by `os.Root` |
| [#6](https://github.com/pkkummermo/govalin/security/code-scanning/6) | `go/clear-text-logging` | **Bounded** — user agent and path capped at 256 chars |
| [#5](https://github.com/pkkummermo/govalin/security/code-scanning/5) | `go/clear-text-logging` | **Dismissed** as a false positive — see below |

## Alert #2 — static serving is confined by the OS, not by string comparison

`handle` resolved the request path against the static directory, cleaned it, and compared the prefix against the cleaned root. That rejects `../` traversal, but path arithmetic describes *names*, not what they *resolve to* — a symlink inside the static directory is contained as a path while pointing anywhere on the filesystem, so it passed the check and was then stat'd and served.

Static serving now opens the configured directory as an `os.Root` and does every read through it, so the kernel refuses any name that leaves the root, symlinks included. Two consequences are deliberate:

- an unresolvable name is answered **404 directly** rather than handed to `http.FileServer` — an escaping name is not a *missing* file to the file server, so it would answer 500 and thereby confirm something is there;
- a mount whose directory cannot be opened is a **500** with an actionable log line, not a 404 for every request.

The on-disk and embedded branches also collapse into one — `os.Root.FS()` is an `fs.FS`, so both share one stat and one file server.

## Alert #6 — user agent and path are bounded before logging

The access log recorded the request path and `User-Agent` verbatim. Both are client-chosen and neither is capped by anything else, so a request decided how many bytes its log line cost — up to `MaxHeaderBytes` (1MB by default). `logSafeValue` bounds them at 256 characters, marking truncation with `…` so a cut value is never read as what the client sent. The bound counts characters, so multi-byte text is not cut mid-rune.

It also drops control characters, but that part is defence in depth rather than a live hole. Measured against the real stack:

- control bytes in a **header** value never arrive — net/http answers **400** to a request carrying `ESC`, `NUL` or `DEL`, before any handler runs. Only tab and folded continuation lines get through;
- control bytes in a **path** do arrive, since percent-encoding survives the request-line check and `url.Parse` decodes it (`/x%00`, `/x%1b[31m`, `/x%0a` all reach the handler);
- both standard `slog` handlers then escape them, so neither can break a record or reach a terminal raw.

The scrub is kept because it is nearly free and govalin does not choose the handler it logs through — not because the standard ones leak.

## Alert #5 — the logged call ID is not a finding

The same log call records the call ID, which originates in the inbound `X-Govalin-Id` header. That is the feature, not a leak: the header exists so a caller can propagate its own correlation ID, and appearing in every record for the request is the entire point of having one. Nothing sensitive is disclosed — the client reads back an identifier it chose itself.

Nor is there a payload to smuggle through it, per the measurements above: control bytes in a header get the request rejected with 400, and what does get through is escaped by `slog`. The only thing an inbound ID can still do is be long, which is a log-volume question and not what the alert is about.

Constraining it to a bounded printable token would silence the alert at the cost of the propagation the header exists for, so the ID stays verbatim and the alert is dismissed as a false positive.

## Breaking changes

- A static mount whose directory is missing or unreadable answers **500** instead of 404.
- Files reachable only through a symlink out of the static directory are no longer served. A deployment relying on symlinked-in content must move or bind-mount it.
- Access log path and user agent values are capped at 256 characters, appearing truncated with a trailing `…`.

## Verification

- New: `TestStaticFolderSymlinkEscape` (the case prefix containment missed), `TestStaticFolderMissingRoot`, `TestAccessLogSanitizesRequestDerivedValues`, and unit tests for `logSafeValue`.
- `go test ./...`, `go test -race ./...`, `golangci-lint run ./...` and `gofmt -l .` all clean.
- ADR [0006](docs/adr/0006-root-confined-static-serving-and-log-safe-request-values.md) records the decision, the rejected alternatives, and the measured threat model; `CONTEXT.md` gains **Root-confined static access**, **Request-controlled value**, **Log-safe value** and **Correlation ID**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)