### PR TITLE
feat(call): stream responses with Range support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,3 +35,71 @@ jobs:
 
       - name: Race test
         run: go test -race ./...
+
+  # Blocking performance gate. It asserts per-request allocation counts, which
+  # are identical on every run of a given build — unlike wall-clock time on a
+  # shared runner, which swings far enough to fail at random. Scoped to the
+  # baseline toolchain like the race gate, since escape analysis can shift the
+  # counts between Go releases.
+  perf-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.x"
+
+      - name: Allocation budget
+        env:
+          GOVALIN_PERF_GATE: "1"
+        run: go test -run TestAllocationBudget -v .
+
+  # Advisory only: timings from a shared runner are indicative, not a verdict,
+  # so this reports into the job summary and never fails the build.
+  perf-compare:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.25.x"
+
+      - name: Install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@latest
+
+      - name: Benchmark this branch
+        run: go test -run '^$' -bench . -skip LargeBody -benchmem -benchtime 200ms -count 6 . > "$RUNNER_TEMP/new.txt"
+
+      - name: Benchmark the merge base
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          git fetch --no-tags origin "$base" 2>/dev/null || true
+          git worktree add "$RUNNER_TEMP/base" "$base"
+          # The base runs its own benchmarks: a benchmark added or changed by
+          # this PR would not compile there, and copying it in would measure a
+          # file against a tree it was not written for.
+          (cd "$RUNNER_TEMP/base" && go test -run '^$' -bench . -skip LargeBody -benchmem -benchtime 200ms -count 6 .) > "$RUNNER_TEMP/old.txt"
+
+      - name: Compare
+        run: |
+          {
+            echo "## Benchmarks vs merge base"
+            echo
+            if grep -q '^Benchmark' "$RUNNER_TEMP/old.txt"; then
+              echo '```'
+              benchstat "$RUNNER_TEMP/old.txt" "$RUNNER_TEMP/new.txt"
+              echo '```'
+              echo
+              echo "_Shared-runner timings are noisy; treat sec/op as indicative and B/op and allocs/op as reliable. The blocking check is the allocation budget in \`perf-gate\`._"
+            else
+              echo "The merge base has no comparable benchmarks, so there is nothing to compare against."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -116,6 +116,29 @@ _Avoid_: implicit 200 on unflushed status, multiple status writes
 A request whose handler takes ownership of the raw writer (HTTPServe, or a websocket upgrade that hijacks the connection); govalin performs no status flush or response finalization for it.
 _Avoid_: framework-managed finalization on raw handlers, double-writing a bypassed response
 
+**Committed response**:
+A response whose header has reached the wire, whoever put it there — a `Call` body sink, an
+`http.ServeContent` call, a raw write, third-party middleware. Recorded by the writer itself rather
+than declared by the caller, so the framework never has to be told.
+_Avoid_: caller-declared "I wrote it" flags, per-call-site bypass as the way to avoid a double write
+
+**Written status**:
+The status of a **Committed response**, as recorded on the way out. This — not the **Buffered
+status** — is what the access log reports; the buffered value is the fallback for a response that
+never reached the wire through govalin.
+_Avoid_: logging the intended status, "the status is whatever `Status()` says"
+
+**Streamed body**:
+A response body copied straight from a reader onto the connection, never held in memory. Of unknown
+length and not seekable, so it is chunked and carries no ranges.
+_Avoid_: buffer-then-write for large bodies, "read it all first to know the length"
+
+**Ranged content**:
+A response body the client may ask for part of, byte range by byte range, because the content can be
+addressed at an offset — by seeking, or by reading at an offset with a known total size. What makes a
+large download resumable and a large file seekable.
+_Avoid_: whole-body-only downloads, buffering a remote object to make it seekable
+
 **Bound port**:
 The port the server is actually listening on, read from the live listener (`listener.Addr()`), as opposed to the configured port. When the configured port is `0` the OS assigns a free port, so only the bound port is authoritative. Exposed to plugins via `App.Port()`.
 _Avoid_: configured-port-as-truth, advertising a port the server is not listening on
@@ -221,6 +244,14 @@ _Avoid_: sanitizing the ID for the log, framework-imposed ID formats that break 
 - A **Buffered status** becomes visible to the client only after a **Status flush**
 - A **Status flush** happens at most once per request: on first body write, or otherwise at end of lifecycle
 - **Lifecycle bypass** suppresses **Status flush** — the handler owns response finalization
+- A **Status flush** never touches a **Committed response**; that, not **Lifecycle bypass**, is what
+  keeps the framework from writing a status twice
+- **Lifecycle bypass** is about ownership of the raw writer, not about avoiding a double write
+- The access log records the **Written status** of a **Committed response**, falling back to the
+  **Buffered status** only when nothing was committed through govalin
+- A **Committed response** counts as a handled request: the lifecycle appends no not-found body to it
+- A **Streamed body** and **Ranged content** are the two shapes of a body too large to buffer; the
+  content decides which one it can be
 - The **App-under-test** relies on **Startup-event readiness**, which reads the **Bound port** only after the startup event fires
 - **Test-scoped failure** and **Status-agnostic body access** define the public test client's failure semantics: transport errors fail the test, HTTP error statuses do not
 - The **Plugin complexity boundary** does not exclude test tooling from the core module: a test package adds no dependency cost to consumers who never import it

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -116,6 +116,13 @@ _Avoid_: implicit 200 on unflushed status, multiple status writes
 A request whose handler takes ownership of the raw writer (HTTPServe, or a websocket upgrade that hijacks the connection); govalin performs no status flush or response finalization for it.
 _Avoid_: framework-managed finalization on raw handlers, double-writing a bypassed response
 
+**Allocation budget**:
+The number of allocations a request shape is allowed to cost, asserted in CI. Measured from what the
+code does today, not aimed at; exact rather than statistical, because an allocation count is the same
+on every run of a build while wall-clock time on a shared runner is not. Raising one is a decision
+taken in the diff that needs it, with the reason in the commit.
+_Avoid_: timing thresholds as a blocking gate, nudging the number until the gate passes
+
 **Committed response**:
 A response whose header has reached the wire, whoever put it there — a `Call` body sink, an
 `http.ServeContent` call, a raw write, third-party middleware. Recorded by the writer itself rather
@@ -225,6 +232,9 @@ _Avoid_: sanitizing the ID for the log, framework-imposed ID formats that break 
 - **Scope-frozen phase one** limits changes to race elimination only
 - **Phase-one done criteria** require both race and default test passes with unchanged helper signatures
 - A **Policy-enforced gate** ensures race-cleanliness is continuously verified pre-merge
+- An **Allocation budget** is a **Stability gate** for cost, enforced in its own job on the baseline
+  toolchain for the same reason race detection is: an isolated, trustworthy signal
+- Benchmark timings are advisory context for an **Allocation budget**, never the gate themselves
 - **Gate-first execution order** resolves blocking quality gates before static-route redesign
 - **Canonical static mount URL** is the trailing-slash path, with redirect from non-slash form
 - **Permanent canonical redirect** applies to static mount root normalization

--- a/README.md
+++ b/README.md
@@ -24,6 +24,45 @@ func main() {
 }
 ```
 
+## Serving files and large bodies
+
+`Text`, `HTML` and `JSON` are for bodies that fit in memory. For anything bigger, `Call` streams:
+
+```go
+govalin.New().
+	// Any reader, of any length: nothing is buffered.
+	Get("/logs", func(call *govalin.Call) {
+		if err := call.Stream("text/plain", logReader()); err != nil {
+			call.Error(err)
+		}
+	}).
+	// Seekable content, with Range support: resumable downloads and seeking.
+	Get("/files/{name}", func(call *govalin.Call) {
+		file, err := os.Open(call.PathParam("name"))
+		if err != nil {
+			call.Error(err)
+			return
+		}
+		defer file.Close()
+
+		info, _ := file.Stat()
+		call.ServeContent(info.Name(), info.ModTime(), file)
+	}).
+	Start(7070)
+```
+
+- `Stream(contentType, reader)` copies a reader onto the response. Unknown length, no ranges.
+- `ServeContent(name, modTime, readSeeker)` handles `Range`, `If-Range`, `206`, `416`, `304`, `HEAD`
+  and `Content-Length` for you, and picks the content type from the name.
+- `ServeContentAt(name, modTime, readerAt, size)` is the same for content you can only read at an
+  offset — a remote object exposing ranged GETs — so a multi-gigabyte object is served with working
+  Range requests and nothing buffered.
+- `Download(filename, modTime, readSeeker)` is `ServeContent` offered as an attachment to save.
+
+`Stream` returns a failure to read your content. A failure to write it out — a client that hangs up
+mid-body — is not returned: the header is already sent, so there is nothing left to answer with. It
+is logged at debug level.
+
 ## Testing your app
 
 Govalin ships a test harness, [`govalintest`](govalintest/), for testing your application over real HTTP. Hand it your own app — built by your own constructor, with your config, plugins and routes — and it starts it on an OS-assigned port, waits for it to be ready, and shuts it down when the test finishes:
@@ -51,6 +90,7 @@ A few things to know:
 - `Post`, `Put` and `Patch` send `string`, `[]byte` and `io.Reader` bodies as-is; any other value is JSON-encoded with `Content-Type: application/json`.
 - For anything custom (headers, auth, exotic verbs), build an `*http.Request` with a relative path and pass it to `client.Do(...)`, or grab the underlying client with `client.HTTP()`.
 - `client.Websocket(path)` connects a websocket to your app.
+- `client.GetRange(path, from, to)` asks for a byte range, for asserting on `206` responses.
 - Harness knobs live in `govalintest.TestWithOptions(t, app, govalintest.Options{...}, fn)` — the zero value always means sane defaults.
 
 ## Motivation

--- a/bench_stream_test.go
+++ b/bench_stream_test.go
@@ -1,0 +1,50 @@
+package govalin
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+	"time"
+)
+
+// BenchmarkStreamLargeBody measures the new sink against the raw-writer
+// workaround it replaces, over a real connection.
+func BenchmarkStreamLargeBody(b *testing.B) {
+	body := make([]byte, benchBodySize)
+
+	host := startBenchApp(b, func(app *App) {
+		app.Get("/stream", func(call *Call) {
+			_ = call.Stream("application/octet-stream", newRepeatReader(body))
+		})
+	})
+
+	benchDownload(b, host, "/stream", benchBodySize)
+}
+
+// BenchmarkServeContentLargeBody is the seekable path, which is what static
+// mounts now use.
+func BenchmarkServeContentLargeBody(b *testing.B) {
+	body := make([]byte, benchBodySize)
+
+	host := startBenchApp(b, func(app *App) {
+		app.Get("/content", func(call *Call) {
+			call.ServeContent("payload.bin", time.Unix(0, 0), bytes.NewReader(body))
+		})
+	})
+
+	benchDownload(b, host, "/content", benchBodySize)
+}
+
+// BenchmarkServeContentSmallBody is the shape a static mount serves most: a
+// small file, where per-request overhead dominates throughput.
+func BenchmarkServeContentSmallBody(b *testing.B) {
+	body := make([]byte, 4<<10)
+
+	app := benchApp(func(app *App) {
+		app.Get("/content", func(call *Call) {
+			call.ServeContent("payload.bin", time.Unix(0, 0), bytes.NewReader(body))
+		})
+	})
+
+	benchServe(b, app, http.MethodGet, "/content", http.StatusOK, len(body))
+}

--- a/bench_test.go
+++ b/bench_test.go
@@ -1,0 +1,283 @@
+package govalin
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// discardWriter is a response writer that keeps nothing but the shape of the
+// response, so a benchmark measures the framework rather than the recorder it
+// writes into — while still being able to prove it measured what it meant to.
+type discardWriter struct {
+	header  http.Header
+	status  int
+	written int
+}
+
+func (writer *discardWriter) Header() http.Header {
+	return writer.header
+}
+
+func (writer *discardWriter) Write(data []byte) (int, error) {
+	writer.written += len(data)
+
+	return len(data), nil
+}
+
+func (writer *discardWriter) WriteHeader(status int) {
+	writer.status = status
+}
+
+// observedStatus mirrors net/http: a body written without an explicit header is
+// a 200.
+func (writer *discardWriter) observedStatus() int {
+	if writer.status == 0 && writer.written > 0 {
+		return http.StatusOK
+	}
+
+	return writer.status
+}
+
+func (writer *discardWriter) reset() {
+	clear(writer.header)
+	writer.status = 0
+	writer.written = 0
+}
+
+// benchApp builds an app with logging off, ready to serve through
+// rootHandlerFunc without binding a listener.
+func benchApp(register func(app *App)) *App {
+	app := New(func(config *Config) {
+		config.EnableAccessLog(false)
+		config.EnableStartupLog(false)
+	})
+	register(app)
+
+	return app
+}
+
+// benchServe drives one request shape through the whole request lifecycle.
+//
+// It checks the response before timing anything: a benchmark that silently
+// measures a redirect or an error instead of the work it names is worse than no
+// benchmark at all.
+func benchServe(b *testing.B, app *App, method string, target string, wantStatus int, wantBody int) {
+	b.Helper()
+
+	request := httptest.NewRequest(method, target, nil)
+	writer := &discardWriter{header: http.Header{}}
+
+	app.rootHandlerFunc(writer, request)
+	if writer.observedStatus() != wantStatus || writer.written < wantBody {
+		b.Fatalf(
+			"%s %s answered %d with %d body bytes, expected %d with at least %d",
+			method, target, writer.observedStatus(), writer.written, wantStatus, wantBody,
+		)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		writer.reset()
+		app.rootHandlerFunc(writer, request)
+	}
+}
+
+func BenchmarkText(b *testing.B) {
+	app := benchApp(func(app *App) {
+		app.Get("/text", func(call *Call) { call.Text("Hello world") })
+	})
+
+	benchServe(b, app, http.MethodGet, "/text", http.StatusOK, 11)
+}
+
+func BenchmarkJSON(b *testing.B) {
+	type payload struct {
+		Name  string `json:"name"`
+		Count int    `json:"count"`
+	}
+
+	app := benchApp(func(app *App) {
+		app.Get("/json", func(call *Call) { call.JSON(payload{Name: "govalin", Count: 42}) })
+	})
+
+	benchServe(b, app, http.MethodGet, "/json", http.StatusOK, 25)
+}
+
+// BenchmarkStatusOnly is the end-of-lifecycle status flush on its own: no body,
+// so the only write is the one the framework makes.
+func BenchmarkStatusOnly(b *testing.B) {
+	app := benchApp(func(app *App) {
+		app.Get("/status", func(call *Call) { call.Status(http.StatusNoContent) })
+	})
+
+	benchServe(b, app, http.MethodGet, "/status", http.StatusNoContent, 0)
+}
+
+func BenchmarkNotFound(b *testing.B) {
+	app := benchApp(func(app *App) {
+		app.Get("/text", func(call *Call) { call.Text("Hello world") })
+	})
+
+	benchServe(b, app, http.MethodGet, "/missing", http.StatusNotFound, 50)
+}
+
+// BenchmarkBeforeAfterHandlers covers the path with the most lifecycle checks.
+func BenchmarkBeforeAfterHandlers(b *testing.B) {
+	app := benchApp(func(app *App) {
+		app.Before("/*", func(_ *Call) bool { return true })
+		app.Get("/text", func(call *Call) { call.Text("Hello world") })
+		app.After("/*", func(_ *Call) {})
+	})
+
+	benchServe(b, app, http.MethodGet, "/text", http.StatusOK, 11)
+}
+
+// BenchmarkAccessLog includes the log line, which now reads the written status.
+func BenchmarkAccessLog(b *testing.B) {
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	b.Cleanup(func() { slog.SetDefault(previous) })
+
+	app := New(func(config *Config) {
+		config.EnableAccessLog(true)
+		config.EnableStartupLog(false)
+	})
+	app.Get("/text", func(call *Call) { call.Text("Hello world") })
+
+	benchServe(b, app, http.MethodGet, "/text", http.StatusOK, 11)
+}
+
+func BenchmarkStaticFile(b *testing.B) {
+	app := benchApp(func(app *App) {
+		app.Static("/static", func(_ *Call, staticConfig *StaticConfig) {
+			staticConfig.WithStaticPath("internal/testdata/static")
+		})
+	})
+
+	benchServe(b, app, http.MethodGet, "/static/sub/test.html", http.StatusOK, 100)
+}
+
+func BenchmarkHTTPServe(b *testing.B) {
+	app := benchApp(func(app *App) {
+		app.HTTPServe("/raw", func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("Hello world"))
+		})
+	})
+
+	benchServe(b, app, http.MethodGet, "/raw", http.StatusOK, 11)
+}
+
+// startBenchApp starts an app on an OS-assigned port and returns its base URL,
+// so a benchmark can measure the real net/http write path rather than a
+// stand-in writer.
+func startBenchApp(b *testing.B, register func(app *App)) string {
+	b.Helper()
+
+	app := New(func(config *Config) {
+		config.EnableAccessLog(false)
+		config.EnableStartupLog(false)
+	})
+	register(app)
+
+	ready := make(chan struct{})
+	app.Events(func(events *ServerEvents) {
+		events.AddOnServerStartup(func() { close(ready) })
+	})
+
+	go func() { _ = app.Start(0) }()
+	<-ready
+
+	b.Cleanup(func() { _ = app.Shutdown() })
+
+	return fmt.Sprintf("http://localhost:%d", app.Port())
+}
+
+// benchDownload measures throughput of a large body over a real connection,
+// which is where the writer wrapper could cost the sendfile path.
+func benchDownload(b *testing.B, host string, path string, size int) {
+	b.Helper()
+
+	client := &http.Client{Transport: &http.Transport{
+		MaxIdleConnsPerHost: 1,
+		DialContext:         (&net.Dialer{}).DialContext,
+	}}
+
+	b.SetBytes(int64(size))
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for range b.N {
+		response, err := client.Get(host + path)
+		if err != nil {
+			b.Fatalf("request failed: %v", err)
+		}
+		written, copyErr := io.Copy(io.Discard, response.Body)
+		_ = response.Body.Close()
+		if copyErr != nil {
+			b.Fatalf("failed to read body: %v", copyErr)
+		}
+		if written != int64(size) {
+			b.Fatalf("expected %d bytes, got %d", size, written)
+		}
+	}
+}
+
+const benchBodySize = 8 << 20
+
+// BenchmarkRawWriteLargeBody is the workaround this change replaces: a handler
+// copying to the raw writer itself.
+func BenchmarkRawWriteLargeBody(b *testing.B) {
+	body := make([]byte, benchBodySize)
+
+	host := startBenchApp(b, func(app *App) {
+		app.Get("/raw", func(call *Call) {
+			call.Status(http.StatusOK)
+			_, _ = io.Copy(*call.Raw.W, newRepeatReader(body))
+		})
+	})
+
+	benchDownload(b, host, "/raw", benchBodySize)
+}
+
+// BenchmarkHTTPServeLargeBody is the same copy through a bare http.Handler, the
+// only supported escape hatch before this change.
+func BenchmarkHTTPServeLargeBody(b *testing.B) {
+	body := make([]byte, benchBodySize)
+
+	host := startBenchApp(b, func(app *App) {
+		app.HTTPServe("/httpserve", func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = io.Copy(w, newRepeatReader(body))
+		})
+	})
+
+	benchDownload(b, host, "/httpserve", benchBodySize)
+}
+
+// repeatReader serves a fixed payload once, without the seeking a bytes.Reader
+// offers, so every large-body benchmark reads the same way.
+type repeatReader struct {
+	data   []byte
+	offset int
+}
+
+func newRepeatReader(data []byte) *repeatReader {
+	return &repeatReader{data: data}
+}
+
+func (reader *repeatReader) Read(buffer []byte) (int, error) {
+	if reader.offset >= len(reader.data) {
+		return 0, io.EOF
+	}
+
+	read := copy(buffer, reader.data[reader.offset:])
+	reader.offset += read
+
+	return read, nil
+}

--- a/call.go
+++ b/call.go
@@ -39,9 +39,8 @@ type Call struct {
 	id              string
 	config          *Config
 	status          int
-	statusWritten   bool
 	bypassLifecycle bool
-	w               http.ResponseWriter
+	w               *responseWriter
 	req             *http.Request
 	pathParams      map[string]string
 	bodyBytes       []byte
@@ -63,17 +62,23 @@ func newCallFromRequest(w http.ResponseWriter, req *http.Request, config *Config
 		uniqueID = govalinIDHeader[0]
 	}
 
+	// Everything writes through the recording writer, including handlers that
+	// take the raw writer, so govalin can tell whether the response has been
+	// committed no matter who committed it.
+	recordingWriter := newResponseWriter(w)
+	var rawWriter http.ResponseWriter = recordingWriter
+
 	call := Call{
 		id:              uniqueID,
 		config:          config,
-		w:               w,
+		w:               recordingWriter,
 		req:             req,
 		status:          0,
 		bypassLifecycle: false,
 		pathParams:      pathParams,
 		charset:         charsets.UTF8,
 		Raw: raw{
-			W:   &w,
+			W:   &rawWriter,
 			Req: req,
 		},
 	}
@@ -179,7 +184,10 @@ func (call *Call) limitBody(maxSize int64) error {
 		return errBodyTooLarge
 	}
 
-	call.req.Body = http.MaxBytesReader(call.w, call.req.Body, maxSize)
+	// The unwrapped writer: MaxBytesReader type-asserts it against an unexported
+	// net/http interface to close the connection on an over-long body, and an
+	// assertion does not see through the recording wrapper.
+	call.req.Body = http.MaxBytesReader(call.w.ResponseWriter, call.req.Body, maxSize)
 
 	return nil
 }
@@ -351,8 +359,11 @@ func (call *Call) multipartForm() (*multipart.Form, error) {
 	return call.req.MultipartForm, nil
 }
 
+// sendStatusOrDefault commits the buffered status, unless the response has
+// already been committed by someone else — a body sink, http.ServeContent, or a
+// handler writing to the raw writer.
 func (call *Call) sendStatusOrDefault() {
-	if call.statusWritten {
+	if call.committed() {
 		return
 	}
 
@@ -361,7 +372,24 @@ func (call *Call) sendStatusOrDefault() {
 	}
 
 	call.w.WriteHeader(call.status)
-	call.statusWritten = true
+}
+
+// committed reports whether the response header has reached the wire, whoever
+// put it there.
+func (call *Call) committed() bool {
+	return call.w.committed
+}
+
+// writtenStatus reports the status the client got: the one actually written
+// when the response has been committed, falling back to the buffered status for
+// a response that never reached the wire through govalin (a hijacked
+// connection writes its own handshake).
+func (call *Call) writtenStatus() int {
+	if call.w.status != 0 {
+		return call.w.status
+	}
+
+	return call.status
 }
 
 // ID gives an UUIDv4 string that's unique to the call.
@@ -587,10 +615,10 @@ func (call *Call) HeaderOrDefault(key string, def string) string {
 // Set HTTP status that will be used on the response
 //
 // The status is buffered on the call and committed to the response on the first
-// body write (JSON/Text/HTML/Redirect) or, if no body is written, once at the
-// end of the request lifecycle. Setting a status alone is therefore enough to
-// send it. Requests that take over the raw writer (HTTPServe) are never flushed
-// by the framework.
+// body write (JSON/Text/HTML/Redirect/Stream) or, if no body is written, once at
+// the end of the request lifecycle. Setting a status alone is therefore enough
+// to send it. A response already committed by someone else — ServeContent, which
+// picks its own status, or a handler writing to the raw writer — is left alone.
 func (call *Call) Status(statusCode ...int) int {
 	if len(statusCode) > 0 {
 		call.status = statusCode[0]

--- a/docs/adr/0007-response-streaming-and-recorded-response-status.md
+++ b/docs/adr/0007-response-streaming-and-recorded-response-status.md
@@ -112,7 +112,27 @@ directory index; it no longer needs a bypass either.
   start doing so.
 - **Behaviour change**: static routes no longer bypass the lifecycle, so `After` handlers registered
   on a path that also serves static files now run for those requests.
+- **Behaviour change**: an explicit `index.html` request is served rather than redirected.
+  `http.FileServer` canonicalised `/mount/index.html` to `/mount/` with a 301, so a client paid a
+  second round trip for a file it had named exactly; serving through `Call` skips that.
 - A handler writing to `*call.Raw.W` without setting a status is now treated as having handled the
   request, instead of having a 404 body appended to its response.
 - `govalintest` gained `GetRange`, so a ranged response can be asserted on without hand-building a
   request.
+
+## Measured cost
+
+Benchmarks (`bench_test.go`, `bench_stream_test.go`) compared against the commit before this change,
+10 runs each through `benchstat`, on an M4:
+
+- Ordinary responses pay **one 16-byte allocation** for the recording writer and **+1% to +3%**
+  latency (7–20 ns on a ~700 ns request): `Text` +2.9%, `JSON` +1.7%, `StatusOnly` +1.1%,
+  `HTTPServe` +1.5%, before/after handlers +0.35%.
+- A large body over a real connection shows **no measurable change** (`HTTPServe` with an 8 MB body:
+  1.478 ms → 1.487 ms, p=0.24), because the wrapper forwards `ReadFrom` rather than downgrading the
+  copy.
+- Static files got **14% faster** with one allocation fewer, serving through `ServeContent` instead
+  of `http.FileServer`.
+- `ServeContent` moves 8 MB at 8.5 GB/s against 5.6 GB/s for a hand-rolled `io.Copy` to the raw
+  writer — **50% faster with a quarter of the allocations** — so the sink that replaces the
+  workaround is also the faster one.

--- a/docs/adr/0007-response-streaming-and-recorded-response-status.md
+++ b/docs/adr/0007-response-streaming-and-recorded-response-status.md
@@ -1,0 +1,118 @@
+# Response streaming and a recorded response status
+
+## Status
+
+accepted
+
+## Context and decision
+
+`Call` had sinks for bodies it could hold in memory — `Text`, `HTML`, `JSON`, `Redirect` — and nothing
+for a body it could not. An application serving a file, a proxied object or any large payload had to
+write to `*call.Raw.W` itself, which silently broke the response lifecycle: `net/http` emitted the
+header on the first write, the **buffered status** was never marked as flushed, and the
+end-of-lifecycle **status flush** wrote it a second time. The wire result was correct and the log line
+was not — `superfluous response.WriteHeader call` on every such request. The documented way to send a
+large body was therefore "don't use `Call`".
+
+Govalin had hit this itself, twice, in `static.go`, and both sites carried the same four-line comment
+setting the unexported `bypassLifecycle`. That remedy was available to govalin and to nobody else: the
+only escape hatch an application had was `HTTPServe`, which drops it to a bare `http.Handler` and gives
+up path parameters, every `Call` helper and the framework's error conventions.
+
+### The response records what it wrote, so nobody has to declare it
+
+Every call now writes through a `responseWriter` that wraps the `http.ResponseWriter` and records
+whether the response has been committed, and with which status. `sendStatusOrDefault` asks the writer
+instead of a flag it maintains itself, which makes the flush idempotent against *any* write path — a
+`Call` sink, `http.ServeContent`, a raw write, third-party middleware — rather than only against the
+ones that remember to bypass. A **lifecycle bypass** is now about ownership (`HTTPServe`, a hijacked
+websocket), not about avoiding a double write.
+
+Two defects fall out of the same wrapper:
+
+- The access log recorded `call.status`, the *buffered* value. Any handler writing its own header —
+  including govalin's static serving — was logged with whatever `Status()` happened to hold, so a
+  `206 Partial Content` was logged as `200`. It now logs the status recorded by the writer, falling
+  back to the buffered one only when nothing reached the wire through govalin.
+- A handler that wrote to the raw writer without setting a status was treated as not having handled
+  the request, and the lifecycle appended a 404 JSON body to what it had already sent. A committed
+  response is now enough to count as handled.
+
+The wrapper forwards what handlers reach for through the writer: `Flush` for a streamed body,
+`Hijack` because a websocket upgrade type-asserts on `http.Hijacker` directly, `ReadFrom` so
+`io.Copy` keeps `net/http`'s sendfile path instead of falling back to a buffered copy, and `Unwrap`
+for `http.ResponseController`. It deliberately does **not** swallow a second `WriteHeader`: a genuine
+double write in application code should still be reported by `net/http`, and the framework's own
+flush is guarded instead.
+
+`http.MaxBytesReader` is the one caller that gets the *unwrapped* writer. It type-asserts against an
+unexported `net/http` interface to close the connection on an over-long body, and an assertion does
+not see through a wrapper.
+
+### Sinks matched to what the content can do
+
+- `Stream(contentType, reader)` — an `io.Reader` of unknown length. Chunked, no ranges, nothing
+  buffered.
+- `ServeContent(name, modTime, io.ReadSeeker)` — delegates to `http.ServeContent`, which owns Range,
+  If-Range, 206, multipart ranges, 416, 304, HEAD and Content-Length. Reimplementing byte-range
+  parsing to own the status would be the worse trade.
+- `ServeContentAt(name, modTime, io.ReaderAt, size)` — the same, for content that reads at an offset
+  but cannot seek. A remote object store exposes ranged GETs, not a seekable handle;
+  `io.NewSectionReader` turns the size into the seekable view `http.ServeContent` wants, and a seek
+  becomes offset arithmetic the next ranged read resolves. Without it, "serve a 4 GB object with
+  working Range requests" means buffering it first, which is the case the feature exists for.
+- `Download(filename, modTime, content)` — `ServeContent` with `Content-Disposition: attachment`,
+  built by `mime.FormatMediaType` so a name with spaces or non-ASCII characters is encoded rather
+  than pasted into a header.
+
+`Stream` distinguishes the two failures `io.Copy` reports identically, by wrapping the source in a
+reader that keeps its own error. A source that fails is the handler's to know about and is returned.
+A failure on the way out is not: the header is long gone and the body is partly on the wire, so
+there is nothing left to send and nothing for the handler to do. Returning it invites `call.Error` on
+a dead connection, and logging it at `ERROR` makes a routine cancelled download look like a fault; it
+is logged at debug level and reported as success. Classifying the error itself — matching `EPIPE`,
+`ECONNRESET`, a cancelled request context — was tried first and rejected: the list is per-platform
+guesswork, and the context check swallows a genuine source failure during a graceful shutdown, when
+every request's context is cancelled.
+
+For the same reason, a static file that fails part-way through its body is only logged. `call.Error`
+would append a JSON error to a response that is already committed.
+
+`static.go` now serves files through `ServeContent`, so both hand-rolled bypass sites and their
+duplicated comment are gone — and static mounts answer Range requests, which they never did.
+Directories still go to `http.FileServer`, which owns the trailing-slash canonicalization and the
+directory index; it no longer needs a bypass either.
+
+## Considered options
+
+- **A status-recording writer (chosen)** — see above.
+- **Exporting `bypassLifecycle`** — the smallest change: applications could do what `static.go` did.
+  Rejected: it makes every caller responsible for remembering a framework invariant, fixes neither
+  the access log nor the appended-404, and leaves third-party middleware unable to comply at all.
+- **Swallowing a repeated `WriteHeader` in the wrapper** — would silence the warning everywhere,
+  including for application bugs the warning exists to report. Rejected; the framework guards its own
+  flush instead.
+- **`Stream` only, no `ServeContent`** — smaller surface, but a large download could not be resumed
+  and a client could not seek within a file, which is most of the reason to serve one.
+- **Requiring `io.ReadSeeker` everywhere** — would force a remote object to be buffered to disk or
+  memory before it could be served with ranges. Rejected in favour of `ServeContentAt`.
+- **Returning the copy error on a client disconnect** — honest in isolation, but every caller then
+  has to classify a disconnect itself to avoid answering a connection that is gone. Rejected.
+- **Classifying the copy error by errno** — see above. Rejected in favour of recording which side of
+  the copy failed, which is knowable rather than inferred.
+
+## Consequences
+
+- Sending a large body no longer means leaving `Call`, and no longer logs a superfluous
+  `WriteHeader`.
+- The access log reports the status actually sent. A deployment parsing access logs will see `206`,
+  `301` and `416` where it previously saw the buffered value — usually `200`.
+- **Behaviour change**: a static mount now answers `Range` requests with `206`, advertises
+  `Accept-Ranges: bytes` and sets `Last-Modified` from the file. Clients that resume downloads will
+  start doing so.
+- **Behaviour change**: static routes no longer bypass the lifecycle, so `After` handlers registered
+  on a path that also serves static files now run for those requests.
+- A handler writing to `*call.Raw.W` without setting a status is now treated as having handled the
+  request, instead of having a 404 body appended to its response.
+- `govalintest` gained `GetRange`, so a ranged response can be asserted on without hand-building a
+  request.

--- a/docs/adr/0008-allocation-budget-as-the-performance-gate.md
+++ b/docs/adr/0008-allocation-budget-as-the-performance-gate.md
@@ -1,0 +1,68 @@
+# Allocation budget as the performance gate
+
+## Status
+
+accepted
+
+## Context and decision
+
+The response lifecycle change (ADR 0007) put a wrapper in front of every write in the framework. It
+was measured before merging and costs one allocation per request, but nothing stops the next change
+from adding another, and per-request overhead is the one cost an HTTP framework's users cannot
+opt out of. Govalin already enforces correctness as a **policy-enforced gate** in CI; performance had
+no gate at all.
+
+The obvious gate — run the benchmarks, fail on a slowdown — does not work on the runners CI has.
+Shared-vCPU GitHub runners swing wide enough between runs that a threshold tight enough to catch a
+real 5% regression fires constantly on noise, and a gate that fails at random is a gate someone
+switches off.
+
+**Allocation counts are the signal that survives a noisy runner.** For a given build they are
+identical on every run, so the gate is exact rather than statistical: no threshold, no p-value, no
+flake. They are also the right proxy for framework overhead, which is mostly allocation and the GC
+pressure that follows it — the 14% the static path gained in ADR 0007 came with an allocation fewer,
+and the +2% every other route paid came with one more.
+
+`TestAllocationBudget` asserts a measured allocation count per request shape (text, JSON, status
+only, before/after handlers, 404, raw handler, static file) using `testing.AllocsPerRun`. The budgets
+are what the code does today, not aspirations: raising one is a decision taken in the diff that needs
+it, with the reason in the commit message. The failure message says so, because a gate whose fix is
+"edit the number until it passes" gates nothing.
+
+Two scoping decisions:
+
+- The gate runs in a **dedicated job on the baseline toolchain**, mirroring the **Dedicated race gate
+  job** and **Selective race coverage**. Escape analysis and inlining change between Go releases, so
+  a compatibility-matrix job on a newer version could fail on a difference that is not a regression.
+  The counts are identical on Go 1.25 and 1.26 today; that is a measurement, not a guarantee.
+- It is **off by default** (`GOVALIN_PERF_GATE=1`), so a contributor running `go test ./...` on
+  whatever Go version they have does not get a failure that means nothing.
+
+Timings are still reported, as an **advisory** `perf-compare` job that benchstats the PR against its
+merge base into the job summary and never fails the build. The base runs its own benchmark files
+rather than having the PR's copied in: a benchmark the PR adds or changes would not compile there,
+and one that did compile would be measuring a file against a tree it was not written for.
+
+## Considered options
+
+- **Allocation budgets as the gate, timings advisory (chosen)** — see above.
+- **benchstat threshold on sec/op as the gate** — the direct reading of "performance regression", and
+  unusable on shared runners: the noise floor is wider than the regressions worth catching.
+- **A dedicated benchmark machine or a hosted service (Bencher, CodSpeed)** — gives trustworthy
+  timing and continuous history. Rejected for now as infrastructure this project does not have; the
+  advisory job covers the "did something get much slower" case at no cost.
+- **Asserting bytes per operation as well** — bytes move with buffer sizing decisions that are not
+  regressions (a larger read buffer allocates more and copies less). The count is the stable signal.
+- **Always-on budgets in the normal test run** — simplest, and it makes every contributor's local Go
+  version part of the contract. Rejected in favour of an explicit gate job.
+
+## Consequences
+
+- A change that adds a per-request allocation fails CI and has to say so in its diff.
+- The budgets need a deliberate update when the framework legitimately allocates more, and when a Go
+  release shifts them. The gate job reports the measured number alongside the budget, so the update
+  is mechanical once the decision is made.
+- Benchmarks are compiled by the gate job, so one that stops building fails CI rather than rotting
+  unnoticed.
+- The advisory comparison is silent when the merge base has no comparable benchmarks — including for
+  the PR that introduces them.

--- a/govalintest/govalintest.go
+++ b/govalintest/govalintest.go
@@ -76,6 +76,8 @@ func TestWithOptions(t *testing.T, app *govalin.App, opts Options, fn func(clien
 		startupTimeout = defaultStartupTimeout
 	}
 
+	httpClient := &http.Client{}
+
 	ready := make(chan struct{})
 	startErr := make(chan error, 1)
 
@@ -92,6 +94,12 @@ func TestWithOptions(t *testing.T, app *govalin.App, opts Options, fn func(clien
 	}()
 
 	t.Cleanup(func() {
+		// Hand the connections back before shutting down. A keep-alive connection
+		// the server has accepted but not yet read a request from does not count as
+		// idle, so Shutdown would wait for it until the read header timeout and
+		// then fail on its own deadline.
+		httpClient.CloseIdleConnections()
+
 		if err := app.Shutdown(); err != nil {
 			t.Errorf("govalintest: failed to shut down app: %v", err)
 		}
@@ -111,7 +119,7 @@ func TestWithOptions(t *testing.T, app *govalin.App, opts Options, fn func(clien
 	fn(&Client{
 		Host: fmt.Sprintf("http://localhost:%d", app.Port()),
 		t:    t,
-		http: &http.Client{},
+		http: httpClient,
 	})
 }
 

--- a/govalintest/govalintest.go
+++ b/govalintest/govalintest.go
@@ -134,6 +134,29 @@ func (client *Client) GetStatus(path string) int {
 	return client.statusCode(client.request(http.MethodGet, path, nil))
 }
 
+// GetRange performs a GET for a byte range and returns the full response, so a
+// test can assert on the 206, the Content-Range header and the bytes together.
+//
+// The range is inclusive at both ends, as HTTP counts it: from 0 to 1023 asks
+// for the first 1024 bytes. A negative to asks for an open-ended range — from
+// the given offset to the end of the content.
+func (client *Client) GetRange(path string, from int64, to int64) *http.Response {
+	client.t.Helper()
+
+	req, err := http.NewRequest(http.MethodGet, client.Host+path, nil)
+	if err != nil {
+		client.t.Fatalf("govalintest: failed to create ranged GET request for %s: %v", path, err)
+	}
+
+	if to < 0 {
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-", from))
+	} else {
+		req.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", from, to))
+	}
+
+	return client.Do(req)
+}
+
 // Head performs a HEAD request and returns the response body.
 func (client *Client) Head(path string) string {
 	client.t.Helper()

--- a/perf_test.go
+++ b/perf_test.go
@@ -1,0 +1,127 @@
+package govalin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+// perfGateEnv turns the allocation gate on. It is off by default because the
+// budgets below hold for one Go version at a time: escape analysis and inlining
+// change between releases, and a compatibility-matrix job on another version
+// would fail on a difference that is not a regression. CI runs this on the
+// baseline toolchain only, the same way race detection is scoped.
+const perfGateEnv = "GOVALIN_PERF_GATE"
+
+// allocationBudget is what a request shape is allowed to allocate.
+//
+// The numbers are measured, not aimed for: they are what the code does today.
+// Raising one is a decision to take deliberately, in the diff that needs it,
+// with the reason in the commit — not a number to nudge until the gate passes.
+type allocationBudget struct {
+	name    string
+	target  string
+	allowed int
+	build   func(app *App)
+}
+
+var allocationBudgets = []allocationBudget{
+	{
+		name:    "text",
+		target:  "/text",
+		allowed: 15,
+		build:   func(app *App) { app.Get("/text", func(call *Call) { call.Text("Hello world") }) },
+	},
+	{
+		name:    "json",
+		target:  "/json",
+		allowed: 15,
+		build: func(app *App) {
+			type payload struct {
+				Name  string `json:"name"`
+				Count int    `json:"count"`
+			}
+
+			app.Get("/json", func(call *Call) { call.JSON(payload{Name: "govalin", Count: 42}) })
+		},
+	},
+	{
+		name:    "status only",
+		target:  "/status",
+		allowed: 12,
+		build:   func(app *App) { app.Get("/status", func(call *Call) { call.Status(http.StatusNoContent) }) },
+	},
+	{
+		name:    "before and after handlers",
+		target:  "/text",
+		allowed: 22,
+		build: func(app *App) {
+			app.Before("/*", func(_ *Call) bool { return true })
+			app.Get("/text", func(call *Call) { call.Text("Hello world") })
+			app.After("/*", func(_ *Call) {})
+		},
+	},
+	{
+		name:    "not found",
+		target:  "/missing",
+		allowed: 36,
+		build:   func(app *App) { app.Get("/text", func(call *Call) { call.Text("Hello world") }) },
+	},
+	{
+		name:    "raw handler",
+		target:  "/raw",
+		allowed: 12,
+		build: func(app *App) {
+			app.HTTPServe("/raw", func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte("Hello world"))
+			})
+		},
+	},
+	{
+		name:    "static file",
+		target:  "/static/sub/test.html",
+		allowed: 45,
+		build: func(app *App) {
+			app.Static("/static", func(_ *Call, staticConfig *StaticConfig) {
+				staticConfig.WithStaticPath("internal/testdata/static")
+			})
+		},
+	},
+}
+
+// TestAllocationBudget is the performance gate.
+//
+// It counts allocations rather than timing anything: an allocation count is the
+// same on every run of a given build, while wall-clock time on a shared CI
+// runner is not, and a gate that fails at random gets switched off. Per-request
+// allocations are also what an HTTP framework's overhead actually consists of.
+func TestAllocationBudget(t *testing.T) {
+	if os.Getenv(perfGateEnv) == "" {
+		t.Skipf("performance gate is off; set %s=1 to run it", perfGateEnv)
+	}
+
+	for _, budget := range allocationBudgets {
+		t.Run(budget.name, func(t *testing.T) {
+			app := benchApp(budget.build)
+			request := httptest.NewRequest(http.MethodGet, budget.target, nil)
+			writer := &discardWriter{header: http.Header{}}
+
+			allocations := int(testing.AllocsPerRun(200, func() {
+				writer.reset()
+				app.rootHandlerFunc(writer, request)
+			}))
+
+			if allocations > budget.allowed {
+				t.Errorf(
+					"%s allocates %d times per request, budget is %d.\n"+
+						"If the extra allocation is intended, raise the budget in perf_test.go "+
+						"in the same commit and say why.",
+					budget.name, allocations, budget.allowed,
+				)
+			}
+
+			t.Logf("%s: %d allocations per request (budget %d)", budget.name, allocations, budget.allowed)
+		})
+	}
+}

--- a/responsewriter.go
+++ b/responsewriter.go
@@ -29,8 +29,10 @@ func newResponseWriter(writer http.ResponseWriter) *responseWriter {
 // framework's own status flush is guarded by the committed flag instead.
 func (writer *responseWriter) WriteHeader(status int) {
 	// 1xx responses are informational: net/http may send several and the real
-	// status still follows, so they do not commit the response.
-	if status >= http.StatusOK && !writer.committed {
+	// status still follows, so they do not commit the response. 101 is the
+	// exception net/http itself makes — nothing follows a protocol switch, so it
+	// is a final status.
+	if !writer.committed && (status >= http.StatusOK || status == http.StatusSwitchingProtocols) {
 		writer.status = status
 		writer.committed = true
 	}
@@ -57,10 +59,16 @@ func (writer *responseWriter) ReadFrom(reader io.Reader) (int64, error) {
 	return io.Copy(writer.ResponseWriter, reader)
 }
 
+// Flush pushes buffered bytes to the client. net/http headers a response that
+// is flushed before anything was written, so a flush commits it.
 func (writer *responseWriter) Flush() {
-	if flusher, ok := writer.ResponseWriter.(http.Flusher); ok {
-		flusher.Flush()
+	flusher, ok := writer.ResponseWriter.(http.Flusher)
+	if !ok {
+		return
 	}
+
+	writer.markCommitted()
+	flusher.Flush()
 }
 
 // Hijack hands over the connection — a websocket upgrade type-asserts on

--- a/responsewriter.go
+++ b/responsewriter.go
@@ -1,0 +1,99 @@
+package govalin
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+)
+
+// responseWriter records the committed response: whether the header has reached
+// the wire, and with which written status.
+//
+// Everything writes through it — a Call body sink, http.ServeContent, an
+// HTTPServe handler, third-party middleware — so govalin knows a response has
+// been committed without asking callers to declare it.
+type responseWriter struct {
+	http.ResponseWriter
+	status    int
+	committed bool
+}
+
+func newResponseWriter(writer http.ResponseWriter) *responseWriter {
+	return &responseWriter{ResponseWriter: writer}
+}
+
+// WriteHeader records the status and passes it on unchanged. A repeated call is
+// still forwarded, so net/http keeps reporting a genuine double write; the
+// framework's own status flush is guarded by the committed flag instead.
+func (writer *responseWriter) WriteHeader(status int) {
+	// 1xx responses are informational: net/http may send several and the real
+	// status still follows, so they do not commit the response.
+	if status >= http.StatusOK && !writer.committed {
+		writer.status = status
+		writer.committed = true
+	}
+
+	writer.ResponseWriter.WriteHeader(status)
+}
+
+// Write records the implicit 200 net/http commits for an unheadered body.
+func (writer *responseWriter) Write(data []byte) (int, error) {
+	writer.markCommitted()
+
+	return writer.ResponseWriter.Write(data)
+}
+
+// ReadFrom keeps net/http's sendfile path: io.Copy prefers an io.ReaderFrom, and
+// without this every streamed body would fall back to a buffered copy.
+func (writer *responseWriter) ReadFrom(reader io.Reader) (int64, error) {
+	writer.markCommitted()
+
+	if readerFrom, ok := writer.ResponseWriter.(io.ReaderFrom); ok {
+		return readerFrom.ReadFrom(reader)
+	}
+
+	return io.Copy(writer.ResponseWriter, reader)
+}
+
+func (writer *responseWriter) Flush() {
+	if flusher, ok := writer.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+// Hijack hands over the connection — a websocket upgrade type-asserts on
+// http.Hijacker directly, so the wrapper has to carry it. What goes onto the
+// connection from here is no longer net/http's to header, so the response counts
+// as committed.
+func (writer *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := writer.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("the underlying response writer does not support hijacking")
+	}
+
+	conn, readWriter, err := hijacker.Hijack()
+	if err == nil {
+		writer.committed = true
+	}
+
+	return conn, readWriter, err
+}
+
+// Unwrap exposes the wrapped writer to http.ResponseController, which is how a
+// handler reaches capabilities the wrapper does not implement itself.
+func (writer *responseWriter) Unwrap() http.ResponseWriter {
+	return writer.ResponseWriter
+}
+
+// markCommitted records the implicit 200 that a body write commits. net/http
+// headers a zero-byte write the same way, so no length check is needed.
+func (writer *responseWriter) markCommitted() {
+	if writer.committed {
+		return
+	}
+
+	writer.status = http.StatusOK
+	writer.committed = true
+}

--- a/responsewriter_test.go
+++ b/responsewriter_test.go
@@ -1,0 +1,101 @@
+package govalin
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestResponseWriterTracksCommitment pins the wrapper to net/http's own rules
+// for when a response is committed. Every divergence is a double-written status
+// or a wrong access log, so the cases are spelled out rather than inferred.
+func TestResponseWriterTracksCommitment(t *testing.T) {
+	tests := []struct {
+		name      string
+		act       func(writer *responseWriter)
+		committed bool
+		status    int
+	}{
+		{
+			// net/http may send several 1xx responses before the real status.
+			name:      "an informational status does not commit",
+			act:       func(writer *responseWriter) { writer.WriteHeader(http.StatusEarlyHints) },
+			committed: false,
+			status:    0,
+		},
+		{
+			// net/http takes the non-informational path for 101: nothing follows a
+			// protocol switch, so it is the final status.
+			name:      "switching protocols commits",
+			act:       func(writer *responseWriter) { writer.WriteHeader(http.StatusSwitchingProtocols) },
+			committed: true,
+			status:    http.StatusSwitchingProtocols,
+		},
+		{
+			name:      "a final status commits",
+			act:       func(writer *responseWriter) { writer.WriteHeader(http.StatusPartialContent) },
+			committed: true,
+			status:    http.StatusPartialContent,
+		},
+		{
+			name:      "a body write commits an implicit 200",
+			act:       func(writer *responseWriter) { _, _ = writer.Write([]byte("body")) },
+			committed: true,
+			status:    http.StatusOK,
+		},
+		{
+			// net/http headers a zero-byte write the same as any other.
+			name:      "an empty write commits",
+			act:       func(writer *responseWriter) { _, _ = writer.Write(nil) },
+			committed: true,
+			status:    http.StatusOK,
+		},
+		{
+			// net/http's FlushError writes a 200 header when none was sent.
+			name:      "a flush commits an implicit 200",
+			act:       func(writer *responseWriter) { writer.Flush() },
+			committed: true,
+			status:    http.StatusOK,
+		},
+		{
+			name:      "a ReadFrom commits an implicit 200",
+			act:       func(writer *responseWriter) { _, _ = writer.ReadFrom(strings.NewReader("body")) },
+			committed: true,
+			status:    http.StatusOK,
+		},
+		{
+			name: "a second status does not overwrite the first",
+			act: func(writer *responseWriter) {
+				writer.WriteHeader(http.StatusCreated)
+				writer.WriteHeader(http.StatusInternalServerError)
+			},
+			committed: true,
+			status:    http.StatusCreated,
+		},
+		{
+			name: "a status after a body write does not overwrite the implicit 200",
+			act: func(writer *responseWriter) {
+				_, _ = writer.Write([]byte("body"))
+				writer.WriteHeader(http.StatusInternalServerError)
+			},
+			committed: true,
+			status:    http.StatusOK,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			writer := newResponseWriter(httptest.NewRecorder())
+
+			test.act(writer)
+
+			if writer.committed != test.committed {
+				t.Errorf("committed is %v, expected %v", writer.committed, test.committed)
+			}
+			if writer.status != test.status {
+				t.Errorf("written status is %d, expected %d", writer.status, test.status)
+			}
+		})
+	}
+}

--- a/server.go
+++ b/server.go
@@ -466,9 +466,11 @@ func (server *App) rootHandlerFunc(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	// No status set, meaning no handlers have handled the request properly,
-	// ie 404 / not found
-	if call.Status() == 0 {
+	// No status set and nothing written, meaning no handlers have handled the
+	// request properly, ie 404 / not found. A handler that wrote the response
+	// itself without setting a status has handled it; appending a 404 body to
+	// what it sent would corrupt the response.
+	if call.Status() == 0 && !call.committed() {
 		server.notFoundHandler(&call)
 	}
 }
@@ -483,7 +485,7 @@ func (server *App) logAccessLog(call *Call, durationInMS float64) {
 		slog.String("method", call.Method()),
 		slog.Float64("duration_in_ms", durationInMS),
 		slog.String("path", logSafeValue(call.URL().Path)),
-		slog.Int("status", call.status),
+		slog.Int("status", call.writtenStatus()),
 		slog.String(
 			"user_agent",
 			logSafeValue(call.UserAgent()),

--- a/static.go
+++ b/static.go
@@ -6,9 +6,10 @@ import (
 	"io"
 	"io/fs"
 	"log/slog"
+	"mime"
 	"net/http"
 	"os"
-	"path/filepath"
+	"path"
 	"strings"
 )
 
@@ -29,57 +30,66 @@ func newStaticConfig() *StaticConfig {
 	}
 }
 
-func (config *StaticConfig) serveIndexFS(call *Call) {
-	// file does not exist, serve index.html
-	file, openIndexErr := config.fsContent.Open("index.html")
-	if openIndexErr != nil {
-		slog.Error(`Failed to open index.html in bundled embedded files.
-This might be due to a misconfigured embedded bundle or simply 
-that the index.html files doesn't exist.`)
-		call.Error(openIndexErr)
-		return
-	}
+// indexFileName is the file served for the mount root and for the SPA fallback.
+const indexFileName = "index.html"
 
-	index, readIndexErr := io.ReadAll(file)
-	if readIndexErr != nil {
-		slog.Error(`Failed to read index.html in bundled embedded files.
-This might be due to a misconfigured embedded bundle or simply 
-that the index.html files doesn't exist.`)
-		call.Error(openIndexErr)
-		return
-	}
-
-	call.Status(http.StatusOK)
-	call.HTML(string(index))
+// serveIndex serves the mount's index.html, for the mount root and for the SPA
+// fallback. A mount without one is a misconfiguration, so it is reported as
+// such rather than as a missing file.
+func (config *StaticConfig) serveIndex(call *Call, hostedFileSystem fs.FS) {
+	failStatic(call, config.serveFile(call, hostedFileSystem, indexFileName), fmt.Sprintf(
+		`Failed to serve %s for the static mount on '%s'.
+This might be due to a misconfigured static path or embedded bundle, or simply
+that the %s file doesn't exist.`, indexFileName, config.hostPath, indexFileName))
 }
 
-func (config *StaticConfig) serveIndexStatic(call *Call) {
-	indexPath := filepath.Join(config.staticPath, "index.html")
-	if _, indexFileDoesNotExist := os.Stat(
-		indexPath,
-	); os.IsNotExist(indexFileDoesNotExist) {
-		slog.Error(fmt.Sprintf(`Failed to read the index.html file in the given static file folder. 
-Are you sure it exists on the given path: '%s'`, indexPath))
-		call.Error(indexFileDoesNotExist)
+// failStatic answers a static file that could not be served. A response already
+// on the wire cannot be turned into an error, so a failure part-way through a
+// body is only logged.
+func failStatic(call *Call, err error, message string) {
+	if err == nil {
 		return
 	}
 
-	// file does not exist, serve index.html
-	call.Status(http.StatusOK)
+	slog.Error(message, "err", err)
 
-	// http.ServeFile takes over the raw writer and writes the response header
-	// itself. Bypass the lifecycle (same contract as HTTPServe) so the buffered
-	// status isn't flushed a second time, which would trigger a superfluous
-	// response.WriteHeader warning.
-	call.bypassLifecycle = true
-	http.ServeFile(*call.Raw.W, call.Raw.Req, filepath.Join(config.staticPath, "index.html"))
+	if !call.committed() {
+		call.Error(err)
+	}
+}
+
+// serveFile sends a file from the mounted file system through Call, so the
+// response stays inside the govalin lifecycle and Range requests are answered.
+func (config *StaticConfig) serveFile(call *Call, hostedFileSystem fs.FS, name string) error {
+	file, openErr := hostedFileSystem.Open(name)
+	if openErr != nil {
+		return openErr
+	}
+	defer func() { _ = file.Close() }()
+
+	fileInfo, statErr := file.Stat()
+	if statErr != nil {
+		return statErr
+	}
+
+	// Range support needs to seek. Every file system govalin mounts (an os.Root
+	// and the embedded FS) gives seekable files; a custom one that does not still
+	// gets served, just without ranges.
+	seekableFile, isSeekable := file.(io.ReadSeeker)
+	if !isSeekable {
+		return call.Stream(mime.TypeByExtension(path.Ext(name)), file)
+	}
+
+	call.ServeContent(name, fileInfo.ModTime(), seekableFile)
+
+	return nil
 }
 
 func (config *StaticConfig) handle(call *Call) {
 	isFS := config.fsContent != nil
 
 	// remove host path
-	path := strings.TrimPrefix(call.URL().Path, config.hostPath)
+	mountPath := strings.TrimPrefix(call.URL().Path, config.hostPath)
 
 	hostedFileSystem := config.fsContent
 
@@ -103,13 +113,13 @@ Are you sure it exists and is readable on the given path: '%s'`, config.staticPa
 
 	// An fs.FS addresses entries relative to its root, and names the root
 	// directory itself "." rather than the empty string.
-	name := strings.TrimPrefix(path, "/")
+	name := strings.TrimPrefix(mountPath, "/")
 	if name == "" {
 		name = "."
 	}
 
 	// check whether a file exists at the given path
-	_, statErr := fs.Stat(hostedFileSystem, name)
+	fileInfo, statErr := fs.Stat(hostedFileSystem, name)
 
 	var pathErr *fs.PathError
 
@@ -118,12 +128,8 @@ Are you sure it exists and is readable on the given path: '%s'`, config.staticPa
 	// Serve index if:
 	// 1. If path is empty (slash root)
 	// 2. if SPA mode is enabled, and if the file doesn't exist
-	if path == "" || (config.spaMode && isNotFoundError) {
-		if isFS {
-			config.serveIndexFS(call)
-		} else {
-			config.serveIndexStatic(call)
-		}
+	if mountPath == "" || (config.spaMode && isNotFoundError) {
+		config.serveIndex(call, hostedFileSystem)
 		return
 	}
 
@@ -142,21 +148,22 @@ Are you sure it exists and is readable on the given path: '%s'`, config.staticPa
 		call.Status(http.StatusInternalServerError)
 		call.Error(statErr)
 		return
-	default:
-		call.Status(http.StatusOK)
+	case fileInfo.IsDir():
+		// A directory is the file server's job: it owns the trailing-slash
+		// canonicalization and the directory index.
+		http.StripPrefix(
+			config.hostPath,
+			http.FileServer(http.FS(hostedFileSystem)),
+		).ServeHTTP(*call.Raw.W, call.Raw.Req)
+
+		return
 	}
 
-	// otherwise, use http.FileServer to serve the file system
-	//
-	// http.FileServer takes over the raw writer and writes the response header
-	// itself. Bypass the lifecycle (same contract as HTTPServe) so the buffered
-	// status isn't flushed a second time, which would trigger a superfluous
-	// response.WriteHeader warning.
-	call.bypassLifecycle = true
-	http.StripPrefix(
-		config.hostPath,
-		http.FileServer(http.FS(hostedFileSystem)),
-	).ServeHTTP(*call.Raw.W, call.Raw.Req)
+	failStatic(
+		call,
+		config.serveFile(call, hostedFileSystem, name),
+		fmt.Sprintf("Failed to serve the static file '%s'", name),
+	)
 }
 
 // HostPath sets the host path for the static handler. This is trimmed from the

--- a/static_test.go
+++ b/static_test.go
@@ -3,6 +3,7 @@ package govalin_test
 import (
 	"embed"
 	"io/fs"
+	"net/http"
 	"os"
 	"path/filepath"
 	"testing"
@@ -166,6 +167,32 @@ func TestStaticServesRanges(t *testing.T) {
 				mount,
 			)
 		}
+	})
+}
+
+// TestStaticServesIndexFileDirectly pins a behaviour change: http.FileServer
+// used to answer an explicit index.html request with a 301 to the directory,
+// costing a second round trip. Serving through Call, the file is simply served.
+func TestStaticServesIndexFileDirectly(t *testing.T) {
+	app := newTestApp()
+	app.Static("/static", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithStaticPath("internal/testdata/static")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		client.HTTP().CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+
+		response := client.GetResponse("/static/index.html")
+
+		assert.Equal(
+			t,
+			200,
+			response.StatusCode,
+			"An explicit index.html request should be served, not redirected",
+		)
+		assert.Contains(t, readBody(t, response), "Hello world", "The index file should be the body")
 	})
 }
 

--- a/static_test.go
+++ b/static_test.go
@@ -133,6 +133,42 @@ func TestStaticFolder(t *testing.T) {
 	})
 }
 
+// TestStaticServesRanges covers static files going through Call rather than
+// past it: a large file can be resumed and seeked into, on both mount kinds.
+func TestStaticServesRanges(t *testing.T) {
+	staticRoot, _ := fs.Sub(staticTestFiles, "internal/testdata/static")
+
+	app := newTestApp()
+	app.Static("/fs", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithFS(staticRoot)
+	})
+	app.Static("/static", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithStaticPath("internal/testdata/static")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		for _, mount := range []string{"/fs", "/static"} {
+			full := readBody(t, client.GetResponse(mount+"/index.html"))
+
+			partial := client.GetRange(mount+"/index.html", 0, 4)
+			assert.Equal(
+				t,
+				206,
+				partial.StatusCode,
+				"A ranged request for a file on %s should be answered with a 206",
+				mount,
+			)
+			assert.Equal(
+				t,
+				full[:5],
+				readBody(t, partial),
+				"A 206 from %s should carry exactly the requested bytes",
+				mount,
+			)
+		}
+	})
+}
+
 func TestStaticFolderPathTraversal(t *testing.T) {
 	app := newTestApp()
 	app.Static("/static", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {

--- a/stream.go
+++ b/stream.go
@@ -1,0 +1,111 @@
+package govalin
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime"
+	"net/http"
+	"time"
+
+	"github.com/pkkummermo/govalin/internal/http/headers"
+)
+
+// Stream copies the reader into the response body, buffering nothing.
+//
+// It is the sink for a body too large to hold in memory. The buffered status is
+// committed first (200 OK by default), so govalin owns the response and no
+// lifecycle bypass is needed. An empty contentType leaves the content type to
+// net/http, which sniffs it from the first bytes. The length is unknown and the
+// reader cannot seek, so the body is chunked and carries no ranges — use
+// ServeContent for content that can seek.
+//
+// A failure to read the source is returned. A failure to write it out is not:
+// the header is long gone, so there is no error left to send and nothing for the
+// caller to do. It is logged at debug level and reported as success.
+func (call *Call) Stream(contentType string, reader io.Reader) error {
+	if contentType != "" {
+		call.w.Header().Set(headers.ContentType, contentType)
+	}
+
+	call.sendStatusOrDefault()
+
+	// io.Copy reports a read and a write failure the same way, and the two call
+	// for opposite answers, so the source keeps its own error.
+	source := &sourceReader{reader: reader}
+
+	if _, err := io.Copy(call.w, source); err != nil {
+		if source.err != nil {
+			return fmt.Errorf("failed to read the streamed body. %w", source.err)
+		}
+
+		slog.Debug("Failed to write the streamed body, the response is already on the wire",
+			"err", err, "id", call.ID())
+	}
+
+	return nil
+}
+
+// sourceReader remembers why the content stopped reading, so a failure of the
+// source is not mistaken for a client that hung up.
+type sourceReader struct {
+	reader io.Reader
+	err    error
+}
+
+func (source *sourceReader) Read(buffer []byte) (int, error) {
+	read, err := source.reader.Read(buffer)
+	if err != nil && !errors.Is(err, io.EOF) {
+		source.err = err
+	}
+
+	return read, err
+}
+
+// ServeContent sends seekable content as the response body, with Range support.
+//
+// It delegates to http.ServeContent, which resolves Range and If-Range and
+// answers 206 (including multipart ranges), 416, 304 and HEAD, sets
+// Content-Length, and derives the content type from the name's extension unless
+// the handler set one. A zero modTime leaves out Last-Modified.
+//
+// http.ServeContent picks the status itself, so a status buffered with Status is
+// not used. The response is committed here and the lifecycle leaves it alone.
+func (call *Call) ServeContent(name string, modTime time.Time, content io.ReadSeeker) {
+	http.ServeContent(call.w, call.req, name, modTime, content)
+
+	// Keep the buffered status in step with what went out, so after handlers see
+	// the real status.
+	call.status = call.w.status
+}
+
+// ServeContentAt is ServeContent for content that reads at an offset but cannot
+// seek — a remote object exposing ranged GETs rather than a handle.
+//
+// The size is the full length of the content, and is what makes a Range request
+// resolvable without reading anything ahead of it: a seek becomes offset
+// arithmetic that the next ranged read resolves.
+func (call *Call) ServeContentAt(name string, modTime time.Time, content io.ReaderAt, size int64) {
+	call.ServeContent(name, modTime, io.NewSectionReader(content, 0, size))
+}
+
+// Download is ServeContent offered to the client as a file to save, by setting
+// Content-Disposition: attachment with the given filename.
+func (call *Call) Download(filename string, modTime time.Time, content io.ReadSeeker) {
+	call.w.Header().Set(headers.ContentDisposition, attachmentDisposition(filename))
+	call.ServeContent(filename, modTime, content)
+}
+
+// attachmentDisposition builds the Content-Disposition value for a download.
+// mime.FormatMediaType quotes and escapes the name and encodes a non-ASCII one
+// per RFC 2231; a name it cannot represent falls back to a bare attachment
+// rather than an unparseable header.
+func attachmentDisposition(filename string) string {
+	disposition := mime.FormatMediaType("attachment", map[string]string{"filename": filename})
+	if disposition == "" {
+		return "attachment"
+	}
+
+	return disposition
+}

--- a/stream_test.go
+++ b/stream_test.go
@@ -149,6 +149,66 @@ func TestStreamClientDisconnectIsNotAnError(t *testing.T) {
 	})
 }
 
+// TestStreamSniffsAnEmptyContentType covers the documented contract for an
+// empty content type. Committing the status first does not prevent sniffing:
+// net/http records the status on WriteHeader but writes (and sniffs) the header
+// when the first body bytes are flushed.
+func TestStreamSniffsAnEmptyContentType(t *testing.T) {
+	app := newTestApp()
+	app.Get("/sniff", func(call *govalin.Call) {
+		assert.Nil(t, call.Stream("", strings.NewReader("<!DOCTYPE html><html><body>hi</body></html>")))
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.GetResponse("/sniff")
+		_ = readBody(t, response)
+
+		assert.Equal(
+			t,
+			"text/html; charset=utf-8",
+			response.Header.Get("Content-Type"),
+			"An empty content type should be sniffed from the body by net/http",
+		)
+	})
+}
+
+// TestFlushedResponseIsNotWrittenTwice covers a handler that flushes without
+// writing a body: net/http headers the response with an implicit 200, so the
+// lifecycle must treat it as committed. Otherwise it flushes a second status —
+// the superfluous WriteHeader this change exists to prevent, caught for the
+// whole package by TestMain.
+func TestFlushedResponseIsNotWrittenTwice(t *testing.T) {
+	var buf syncBuffer
+
+	app := newAccessLogApp(true, func(app *govalin.App) {
+		app.Get("/flush", func(call *govalin.Call) {
+			call.Status(http.StatusAccepted)
+			assert.Nil(t, http.NewResponseController(*call.Raw.W).Flush())
+		})
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		defer captureAccessLog(&buf)()
+
+		response := client.GetResponse("/flush")
+		_ = readBody(t, response)
+		time.Sleep(accessLogSettleTime)
+
+		assert.Equal(
+			t,
+			http.StatusOK,
+			response.StatusCode,
+			"A flush commits the 200 net/http sends, whatever status was buffered",
+		)
+		assert.Contains(
+			t,
+			buf.String(),
+			"status=200",
+			"The access log should record the status the flush committed, not the buffered one",
+		)
+	})
+}
+
 // TestStreamReportsASourceFailure is the other half of the disconnect case: a
 // failure to read the content is the handler's to know about, and must not be
 // waved away as a client that hung up.

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,0 +1,404 @@
+package govalin_test
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pkkummermo/govalin"
+	"github.com/pkkummermo/govalin/govalintest"
+	"github.com/stretchr/testify/assert"
+)
+
+// streamBody builds a deterministic payload of the given size so a ranged
+// response can be checked against the bytes it should have returned.
+func streamBody(size int) []byte {
+	body := make([]byte, size)
+	for i := range body {
+		body[i] = byte('a' + i%26)
+	}
+
+	return body
+}
+
+// readerAtOnly exposes a payload as an io.ReaderAt and nothing else, standing
+// in for a remote object store: ranged reads work, seeking does not exist.
+type readerAtOnly struct {
+	reader *bytes.Reader
+}
+
+func (r readerAtOnly) ReadAt(p []byte, off int64) (int, error) {
+	return r.reader.ReadAt(p, off)
+}
+
+// failingReader stands in for content the server cannot read: a remote object
+// that stops answering part-way through.
+type failingReader struct {
+	err error
+}
+
+func (r failingReader) Read(_ []byte) (int, error) {
+	return 0, r.err
+}
+
+// blockingReader emits chunks until it is exhausted, pausing between them so a
+// disconnecting client is noticed while the body is still being written.
+type blockingReader struct {
+	chunks int
+	chunk  []byte
+}
+
+func (r *blockingReader) Read(p []byte) (int, error) {
+	if r.chunks == 0 {
+		return 0, io.EOF
+	}
+	r.chunks--
+	time.Sleep(time.Millisecond)
+
+	return copy(p, r.chunk), nil
+}
+
+func TestStreamSendsTheWholeBody(t *testing.T) {
+	body := streamBody(2 << 20)
+
+	app := newTestApp()
+	app.Get("/stream", func(call *govalin.Call) {
+		assert.Nil(t, call.Stream("application/octet-stream", bytes.NewReader(body)))
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.GetResponse("/stream")
+		received := readBody(t, response)
+
+		assert.Equal(t, http.StatusOK, response.StatusCode, "A stream defaults to 200 OK")
+		assert.Equal(
+			t,
+			"application/octet-stream",
+			response.Header.Get("Content-Type"),
+			"Stream should set the given content type",
+		)
+		assert.Equal(t, len(body), len(received), "The whole body should reach the client")
+		assert.Equal(t, string(body), received, "The streamed bytes should arrive unchanged")
+	})
+}
+
+func TestStreamUsesTheBufferedStatus(t *testing.T) {
+	app := newTestApp()
+	app.Get("/stream", func(call *govalin.Call) {
+		call.Status(http.StatusAccepted)
+		assert.Nil(t, call.Stream("text/plain", strings.NewReader("accepted")))
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.GetResponse("/stream")
+
+		assert.Equal(t, "accepted", readBody(t, response), "The body should be streamed")
+		assert.Equal(
+			t,
+			http.StatusAccepted,
+			response.StatusCode,
+			"A status set before streaming should be the status sent",
+		)
+	})
+}
+
+// TestStreamClientDisconnectIsNotAnError covers a client that hangs up mid
+// body: the header is long gone and there is nothing the server can do, so the
+// framework must not report it as an error to the handler or to the log.
+func TestStreamClientDisconnectIsNotAnError(t *testing.T) {
+	var buf syncBuffer
+	var streamErr error
+	done := make(chan struct{})
+
+	app := newTestApp()
+	app.Get("/slow", func(call *govalin.Call) {
+		defer close(done)
+		streamErr = call.Stream("application/octet-stream", &blockingReader{
+			chunks: 4096,
+			chunk:  streamBody(32 << 10),
+		})
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		defer captureAccessLog(&buf)()
+
+		response := client.GetResponse("/slow")
+		assert.Equal(t, http.StatusOK, response.StatusCode, "The header is sent before the body stalls")
+		assert.Nil(t, response.Body.Close(), "Hang up while the body is still being written")
+
+		select {
+		case <-done:
+		case <-time.After(10 * time.Second):
+			t.Fatal("the handler never returned after the client disconnected")
+		}
+		time.Sleep(accessLogSettleTime)
+
+		assert.Nil(t, streamErr, "A client that hangs up mid-stream is not a failure of the handler")
+		assert.NotContains(
+			t,
+			buf.String(),
+			"level=ERROR",
+			"A client disconnect should not be logged at error level",
+		)
+	})
+}
+
+// TestStreamReportsASourceFailure is the other half of the disconnect case: a
+// failure to read the content is the handler's to know about, and must not be
+// waved away as a client that hung up.
+func TestStreamReportsASourceFailure(t *testing.T) {
+	sourceErr := errors.New("the object store said no")
+
+	app := newTestApp()
+	app.Get("/stream", func(call *govalin.Call) {
+		err := call.Stream("application/octet-stream", io.MultiReader(
+			bytes.NewReader(streamBody(16)),
+			failingReader{err: sourceErr},
+		))
+
+		assert.ErrorIs(t, err, sourceErr, "A source that fails should be reported to the handler")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.GetResponse("/stream")
+		_ = readBody(t, response)
+
+		assert.Equal(
+			t,
+			http.StatusOK,
+			response.StatusCode,
+			"The header is already sent when the source fails, so the status stands",
+		)
+	})
+}
+
+func TestServeContentSupportsRangeRequests(t *testing.T) {
+	body := streamBody(4 << 10)
+
+	app := newTestApp()
+	app.Get("/content", func(call *govalin.Call) {
+		call.ServeContent("payload.bin", time.Unix(0, 0), bytes.NewReader(body))
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		full := client.GetResponse("/content")
+		assert.Equal(t, http.StatusOK, full.StatusCode, "An unranged request gets the whole body")
+		assert.Equal(t, "bytes", full.Header.Get("Accept-Ranges"), "Ranges should be advertised")
+		assert.Equal(t, string(body), readBody(t, full), "The whole body should be served")
+
+		partial := client.GetRange("/content", 0, 1023)
+		partialBody := readBody(t, partial)
+
+		assert.Equal(t, http.StatusPartialContent, partial.StatusCode, "A ranged request gets a 206")
+		assert.Equal(
+			t,
+			fmt.Sprintf("bytes 0-1023/%d", len(body)),
+			partial.Header.Get("Content-Range"),
+			"A 206 should describe the range it carries",
+		)
+		assert.Len(t, partialBody, 1024, "A 206 should carry exactly the requested bytes")
+		assert.Equal(t, string(body[:1024]), partialBody, "A 206 should carry the requested bytes")
+
+		tail := client.GetRange("/content", 4000, -1)
+		assert.Equal(t, http.StatusPartialContent, tail.StatusCode, "An open ended range gets a 206")
+		assert.Equal(t, string(body[4000:]), readBody(t, tail), "An open ended range runs to the end")
+	})
+}
+
+func TestServeContentRejectsUnsatisfiableRange(t *testing.T) {
+	body := streamBody(1024)
+
+	app := newTestApp()
+	app.Get("/content", func(call *govalin.Call) {
+		call.ServeContent("payload.bin", time.Unix(0, 0), bytes.NewReader(body))
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.GetRange("/content", 5000, 6000)
+		_ = readBody(t, response)
+
+		assert.Equal(
+			t,
+			http.StatusRequestedRangeNotSatisfiable,
+			response.StatusCode,
+			"A range beyond the content should be refused",
+		)
+	})
+}
+
+func TestServeContentHeadHasHeadersButNoBody(t *testing.T) {
+	body := streamBody(2048)
+
+	app := newTestApp()
+	app.Head("/content", func(call *govalin.Call) {
+		call.ServeContent("payload.bin", time.Unix(0, 0), bytes.NewReader(body))
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.HeadResponse("/content")
+
+		assert.Equal(t, http.StatusOK, response.StatusCode, "A HEAD should answer 200")
+		assert.Equal(
+			t,
+			"2048",
+			response.Header.Get("Content-Length"),
+			"A HEAD should report the length of the body it would have sent",
+		)
+		assert.Equal(t, "", readBody(t, response), "A HEAD carries no body")
+	})
+}
+
+// TestServeContentAtServesRangesWithoutSeeking is the remote-object case: an
+// object store hands out ranged reads, never a seekable handle, and must not
+// have to be buffered to be served.
+func TestServeContentAtServesRangesWithoutSeeking(t *testing.T) {
+	body := streamBody(8 << 10)
+
+	app := newTestApp()
+	app.Get("/object", func(call *govalin.Call) {
+		call.ServeContentAt(
+			"object.bin",
+			time.Unix(0, 0),
+			readerAtOnly{reader: bytes.NewReader(body)},
+			int64(len(body)),
+		)
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		partial := client.GetRange("/object", 1024, 2047)
+
+		assert.Equal(t, http.StatusPartialContent, partial.StatusCode, "A ranged read gets a 206")
+		assert.Equal(
+			t,
+			fmt.Sprintf("bytes 1024-2047/%d", len(body)),
+			partial.Header.Get("Content-Range"),
+			"A 206 should describe the range it carries",
+		)
+		assert.Equal(t, string(body[1024:2048]), readBody(t, partial), "The requested bytes should be served")
+	})
+}
+
+func TestDownloadSendsAnAttachment(t *testing.T) {
+	body := streamBody(512)
+
+	app := newTestApp()
+	app.Get("/download", func(call *govalin.Call) {
+		call.Download("my report.csv", time.Unix(0, 0), bytes.NewReader(body))
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.GetResponse("/download")
+
+		assert.Equal(t, http.StatusOK, response.StatusCode, "A download answers 200")
+		assert.Contains(
+			t,
+			response.Header.Get("Content-Disposition"),
+			"attachment",
+			"A download should be offered as an attachment",
+		)
+		assert.Contains(
+			t,
+			response.Header.Get("Content-Disposition"),
+			`filename="my report.csv"`,
+			"A download should carry the given file name",
+		)
+		assert.Equal(t, string(body), readBody(t, response), "The whole file should be served")
+	})
+}
+
+// TestAccessLogRecordsTheWrittenStatus covers the log reporting what actually
+// went out: a handler that writes the header itself used to be logged with
+// whatever buffered status happened to be set, so a 206 was logged as a 200.
+func TestAccessLogRecordsTheWrittenStatus(t *testing.T) {
+	var buf syncBuffer
+	body := streamBody(4 << 10)
+
+	app := newAccessLogApp(true, func(app *govalin.App) {
+		app.Get("/content", func(call *govalin.Call) {
+			call.ServeContent("payload.bin", time.Unix(0, 0), bytes.NewReader(body))
+		})
+		app.HTTPServe("/raw", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusTeapot)
+		})
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		defer captureAccessLog(&buf)()
+
+		_ = readBody(t, client.GetRange("/content", 0, 1023))
+		client.Get("/raw")
+		time.Sleep(accessLogSettleTime)
+
+		assert.Contains(t, buf.String(), "status=206", "A 206 should be logged as a 206")
+		assert.Contains(
+			t,
+			buf.String(),
+			"status=418",
+			"A status written by a raw handler should be the status logged",
+		)
+	})
+}
+
+// TestRawWriterDoesNotGetANotFoundAppended covers a handler that writes to the
+// raw writer without setting a status: the response is written, so the
+// lifecycle must not treat the request as unhandled and append a 404 body.
+func TestRawWriterDoesNotGetANotFoundAppended(t *testing.T) {
+	app := newTestApp()
+	app.Get("/raw", func(call *govalin.Call) {
+		_, err := (*call.Raw.W).Write([]byte("written by hand"))
+		assert.Nil(t, err)
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.GetResponse("/raw")
+
+		assert.Equal(t, http.StatusOK, response.StatusCode, "An implicit 200 should stand")
+		assert.Equal(
+			t,
+			"written by hand",
+			readBody(t, response),
+			"A hand-written response should not have a 404 body appended to it",
+		)
+	})
+}
+
+// TestConcurrentStreamsAreIndependent guards the response wrapper against
+// shared state between requests.
+func TestConcurrentStreamsAreIndependent(t *testing.T) {
+	body := streamBody(64 << 10)
+
+	app := newTestApp()
+	app.Get("/content", func(call *govalin.Call) {
+		call.ServeContent("payload.bin", time.Unix(0, 0), bytes.NewReader(body))
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		var waitGroup sync.WaitGroup
+		for i := range 8 {
+			waitGroup.Add(1)
+			go func() {
+				defer waitGroup.Done()
+				request, err := http.NewRequest(http.MethodGet, client.Host+"/content", nil)
+				if !assert.Nil(t, err) {
+					return
+				}
+				request.Header.Set("Range", fmt.Sprintf("bytes=%d-%d", i*1024, i*1024+1023))
+				response, doErr := client.HTTP().Do(request) //nolint:bodyclose // closed below
+				if !assert.Nil(t, doErr) {
+					return
+				}
+				defer func() { _ = response.Body.Close() }()
+				received, _ := io.ReadAll(response.Body)
+				assert.Equal(t, http.StatusPartialContent, response.StatusCode)
+				assert.Equal(t, string(body[i*1024:i*1024+1024]), string(received))
+			}()
+		}
+		waitGroup.Wait()
+	})
+}


### PR DESCRIPTION
Closes #79

`Call` had sinks for bodies it could hold in memory and nothing for a body it could not, so sending a large one meant writing to `*call.Raw.W` and breaking the response lifecycle — the buffered status was flushed a second time and net/http logged `superfluous response.WriteHeader call`.

## The mechanism

Every call now writes through a `responseWriter` that records whether the response has been **committed**, and with which **written status**. `sendStatusOrDefault` asks the writer instead of a flag it maintains itself, so the end-of-lifecycle flush is idempotent against *any* write path — a `Call` sink, `http.ServeContent`, a raw write, third-party middleware — not just the ones that remember to bypass. `bypassLifecycle` goes back to meaning ownership of the raw writer (`HTTPServe`, a hijacked websocket), not "avoid a double write".

Two defects fall out of the same wrapper:

- The access log recorded the *buffered* status, so a `206` was logged as `200`. It now logs what was written.
- A handler writing to the raw writer without setting a status was treated as unhandled, and the lifecycle appended a 404 JSON body to what it had already sent.

The wrapper forwards `Flush`, `Hijack` (a websocket upgrade type-asserts on `http.Hijacker` directly), `ReadFrom` (keeps net/http's sendfile path) and `Unwrap`. It deliberately does **not** swallow a second `WriteHeader` — a genuine double write in application code should still be reported. `http.MaxBytesReader` gets the unwrapped writer, since it type-asserts against an unexported net/http interface.

## New API

```go
func (call *Call) Stream(contentType string, reader io.Reader) error
func (call *Call) ServeContent(name string, modTime time.Time, content io.ReadSeeker)
func (call *Call) ServeContentAt(name string, modTime time.Time, content io.ReaderAt, size int64)
func (call *Call) Download(filename string, modTime time.Time, content io.ReadSeeker)
```

`Stream` distinguishes the two failures `io.Copy` reports identically by wrapping the source in a reader that keeps its own error: a source failure is returned, a failure on the way out is not — the header is long gone. Classifying by errno (`EPIPE`, `ECONNRESET`, a cancelled context) was tried first and rejected: it is per-platform guesswork, and the context check swallows a genuine source error during a graceful shutdown.

`static.go` serves through `ServeContent`, so both hand-rolled `bypassLifecycle` sites and their duplicated comment are gone — and static mounts answer Range requests. `govalintest` gained `GetRange`.

## Measured cost

`benchstat`, 10 runs each against the previous commit, on an M4:

- Ordinary responses: **one 16-byte allocation** and **+1% to +3%** latency (7-20 ns on a ~700 ns request).
- 8 MB body over a real connection: **no measurable change** (1.478 ms -> 1.487 ms, p=0.24) — the `ReadFrom` forwarding is what keeps this flat.
- Static files: **14% faster**, one allocation fewer.
- `ServeContent` moves 8 MB at **8.5 GB/s** against **5.6 GB/s** for a hand-rolled copy to the raw writer, with a quarter of the allocations.

## Behaviour changes

- Static routes no longer bypass the lifecycle, so `After` handlers registered on a path that also serves static files now run for those requests.
- An explicit `index.html` request is served rather than 301-redirected to the directory, saving a round trip. Found because the first version of the static benchmark was measuring that redirect instead of a file; `benchServe` now verifies the response before timing anything.
- A handler writing to `*call.Raw.W` without setting a status no longer gets a 404 body appended.

## Also

`govalintest` hands its connections back before shutting the app down. A keep-alive connection the server has accepted but not yet read from does not count as idle, so `Shutdown` waited on it and failed on its own deadline — a flake reproducing 1 in 15 runs under concurrent requests, 0 in 25 after.

Decisions and rejected alternatives are in `docs/adr/0007-response-streaming-and-recorded-response-status.md`; `CONTEXT.md` gains **Committed response**, **Written status**, **Streamed body** and **Ranged content**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)