### PR TITLE
Cache validation: NotModified for handlers, derived validators for static assets

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -223,6 +223,39 @@ otherwise. It is deliberately *not* a **Log-safe value**: a caller propagates it
 find the request in govalin's log, and appearing verbatim in every record is the point of having one.
 _Avoid_: sanitizing the ID for the log, framework-imposed ID formats that break propagation
 
+**Cache validation**:
+A client asking whether the copy it already holds is still current, and being answered 304 with no
+body when it is. A bandwidth feature, on safe methods only. Distinct from a precondition on an unsafe
+method (`If-Match`, 412), which borrows the same header vocabulary to answer a different question —
+lost updates, not stale copies.
+_Avoid_: "ETag support" as one undivided feature, If-None-Match meaning the same thing on a write as
+on a read
+
+**Validator**:
+The opaque token naming a version of a resource. Supplied by the caller out of something it already
+knows — a row version, an updated_at, a digest — never computed by the framework from a response body
+it has already paid to produce.
+_Avoid_: post-hoc body hashing, buffering a response in order to validate it
+
+**Derived validator**:
+The **Validator** govalin computes for a static asset without being asked: from when the file changed
+if the file system knows, from what the file contains if it does not. A file system reporting no
+modification time is declaring it has no change signal, so content is the only thing left that
+identifies the file.
+_Avoid_: size-only tags for embedded assets, mtime tags from a file system with no clock
+
+**Strong validator**:
+A **Validator** asserting byte-exact identity, sent unprefixed. The weak form (`W/`) asserts only
+equivalence, and a range resume cannot be built on it: the client's `If-Range` is refused and the
+whole body is sent again. Every **Derived validator** is strong.
+_Avoid_: weak tags on rangeable content, `W/` as a default hedge
+
+**Revalidation short-circuit**:
+What a matched **Validator** buys a handler: permission to skip producing a body, never an obligation
+to. The 304 is buffered the moment the match is found, so a handler that produces a body anyway still
+sends a correct empty 304 — it has wasted only its own work.
+_Avoid_: correctness that depends on the caller reading a return value, a body inside a 304
+
 ## Relationships
 
 - A **Race-clean build** is a required outcome of the **Stability gate**
@@ -270,6 +303,11 @@ _Avoid_: sanitizing the ID for the log, framework-imposed ID formats that break 
 - **Root-confined static access** replaces path-string containment: the static mount is a resource the OS confines, not a prefix the framework checks
 - A **Request-controlled value** reaching a log becomes a **Log-safe value** first; there is no path from a header to a log sink that skips it
 - The **Correlation ID** is the deliberate exception: client-chosen and logged verbatim, because propagating it is the feature
+- **Cache validation** is answered on safe methods only; the same header on an unsafe method is a precondition, and out of scope
+- A **Derived validator** exists only for static assets; every other response's **Validator** comes from the caller
+- A **Revalidation short-circuit** buffers 304 like any other **Buffered status**, so **Status flush** and **Committed response** govern it unchanged
+- A 304 carries no representation, so the **Status flush** drops the headers that describe one
+- A **Strong validator** is what keeps **Ranged content** resumable across a revalidation
 
 ## Example dialogue
 
@@ -281,3 +319,4 @@ _Avoid_: sanitizing the ID for the log, framework-imposed ID formats that break 
 - "tests pass" was used to mean only default test execution and also all quality gates; resolved: release readiness requires passing mandatory stability gates, including race checks.
 - CI currently runs default tests but does not run race tests; resolved: race-clean will be enforced in CI as a mandatory gate.
 - Existing HTTP->HTTPS plugin redirect currently uses only URL path and drops query parameters; resolved: query-preserving behavior applies framework-wide and this behavior must be aligned.
+- "ETag support" was used to mean both cache validation and optimistic concurrency control; resolved: this work is cache validation only, and a precondition on an unsafe method is a separate feature that would need its own name.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,43 @@ govalin.New().
 mid-body — is not returned: the header is already sent, so there is nothing left to answer with. It
 is logged at debug level.
 
+## Caching
+
+`NotModified` answers a client that already has the resource, so a revalidation costs headers
+instead of a body:
+
+```go
+govalin.New().
+	Get("/users/{id}", func(call *govalin.Call) {
+		user := store.Load(call.PathParam("id"))
+
+		if call.NotModified(user.Version) {
+			return
+		}
+
+		call.JSON(user)
+	}).
+	Start(7070)
+```
+
+The tag is yours, out of something you already know — a row version, an `updated_at`, a digest.
+Govalin never hashes a response body to make one up: by the time it could, your handler has already
+done all the work the 304 exists to avoid.
+
+- The tag is sent as the `ETag` either way, quoted if you did not quote it.
+- A `true` return means the client's `If-None-Match` named this version, compared the weak way
+  RFC 9110 requires. It is permission to skip the work, not an obligation — a body written anyway is
+  refused, and the client still gets a correct 304.
+- Only `GET` and `HEAD` are answered this way. On a write, `If-None-Match` asks a different question
+  that govalin does not answer for you.
+- To apply one validator to a group of routes, return it from a `Before` handler:
+  `app.Before("/api/*", func(call *govalin.Call) bool { return !call.NotModified(version()) })`.
+
+Static mounts do this for themselves, with no configuration. A file served from disk is validated by
+when it changed and how big it is; an embedded file, which has no modification time to offer, is
+validated by a hash of its content, computed once per file. Both are strong tags, so resumable
+downloads stay resumable.
+
 ## Testing your app
 
 Govalin ships a test harness, [`govalintest`](govalintest/), for testing your application over real HTTP. Hand it your own app — built by your own constructor, with your config, plugins and routes — and it starts it on an OS-assigned port, waits for it to be ready, and shuts it down when the test finishes:

--- a/call.go
+++ b/call.go
@@ -627,6 +627,14 @@ func (call *Call) Status(statusCode ...int) int {
 	return call.status
 }
 
+// writeBody writes a response body, reporting a failure to write it as an error
+// on the call's behalf.
+func (call *Call) writeBody(data []byte) {
+	if _, err := call.w.Write(data); err != nil {
+		slog.Error(fmt.Sprintf("Error when trying write to response, %v", err))
+	}
+}
+
 // Send text as pure text to response
 //
 // Text will set the content-type of the response as text/plain and write it to the response.
@@ -634,11 +642,7 @@ func (call *Call) Status(statusCode ...int) int {
 func (call *Call) Text(text string) {
 	call.w.Header().Add(headers.ContentType, headers.ContentTypeHeader(contenttypes.TextPlain, call.charset))
 	call.sendStatusOrDefault()
-
-	_, err := call.w.Write([]byte(text))
-	if err != nil {
-		slog.Error(fmt.Sprintf("Error when trying write to response, %v", err))
-	}
+	call.writeBody([]byte(text))
 }
 
 // Send text as HTML to response
@@ -648,11 +652,7 @@ func (call *Call) Text(text string) {
 func (call *Call) HTML(text string) {
 	call.w.Header().Add(headers.ContentType, headers.ContentTypeHeader(contenttypes.TextHTML, call.charset))
 	call.sendStatusOrDefault()
-
-	_, err := call.w.Write([]byte(text))
-	if err != nil {
-		slog.Error(fmt.Sprintf("Error when trying write to response, %v", err))
-	}
+	call.writeBody([]byte(text))
 }
 
 // Send obj as JSON to response
@@ -668,11 +668,7 @@ func (call *Call) JSON(obj interface{}) {
 	}
 
 	call.sendStatusOrDefault()
-
-	_, err = call.w.Write(jsonBytes)
-	if err != nil {
-		slog.Error(fmt.Sprintf("error when trying write to response, %v", err))
-	}
+	call.writeBody(jsonBytes)
 }
 
 // Redirect redirects the request to the given URL

--- a/call.go
+++ b/call.go
@@ -371,6 +371,13 @@ func (call *Call) sendStatusOrDefault() {
 		call.status = http.StatusOK
 	}
 
+	// A 304 sends no representation, so the headers describing one are dropped,
+	// whether the handler returned early or wrote a body about to be refused.
+	if call.status == http.StatusNotModified {
+		call.w.Header().Del(headers.ContentType)
+		call.w.Header().Del(headers.ContentLength)
+	}
+
 	call.w.WriteHeader(call.status)
 }
 
@@ -627,10 +634,11 @@ func (call *Call) Status(statusCode ...int) int {
 	return call.status
 }
 
-// writeBody writes a response body, reporting a failure to write it as an error
-// on the call's behalf.
+// writeBody writes a response body. The refusal net/http answers when the status
+// forbids one is not worth reporting: a handler that produced a body after
+// NotModified matched wasted its own work, and the response is still correct.
 func (call *Call) writeBody(data []byte) {
-	if _, err := call.w.Write(data); err != nil {
+	if _, err := call.w.Write(data); err != nil && !errors.Is(err, http.ErrBodyNotAllowed) {
 		slog.Error(fmt.Sprintf("Error when trying write to response, %v", err))
 	}
 }

--- a/docs/adr/0009-user-supplied-cache-validators.md
+++ b/docs/adr/0009-user-supplied-cache-validators.md
@@ -1,0 +1,76 @@
+# User-supplied cache validators
+
+## Status
+
+accepted
+
+## Context and decision
+
+Govalin answered no conditional request of its own. `Call.ServeContent` inherits `If-None-Match`,
+`If-Range` and `If-Modified-Since` handling from `http.ServeContent`, but only against an `ETag` the
+handler had already set — and no handler ever did, because there was no way to. Static mounts fell
+back to modification time, which an embedded FS does not have: every embedded asset reports the zero
+time, so `Last-Modified` was omitted and an embedded bundle was uncacheable outright.
+
+The obvious implementation, and the one every other framework's ETag plugin ships, is to hash the
+response body: wrap the writer, buffer what the handler produces, hash it, compare, and either send
+it or answer 304. **Govalin does not do this.** It inverts what the feature is for — the handler has
+already run the query and marshalled the result before the framework discovers the client needed
+none of it, so the only thing saved is transfer. It also fights the response model of ADR 0007, in
+which everything writes straight through to the wire and `Stream` exists precisely so that a large
+body is never held in memory, and it would put a buffer allocation on every request against the
+budget ADR 0008 made a blocking gate.
+
+So the **Validator** is the caller's, out of something it already knows: `call.NotModified(tag)`
+sets the `ETag`, compares `If-None-Match` by the weak comparison RFC 9110 requires of that header,
+and on a match buffers 304 and returns true. The return is permission to skip the work, not a
+correctness obligation — the buffered 304 means a handler that ignores it and writes a body anyway
+still sends a correct empty 304, because `net/http` refuses a body the status does not allow. This
+is the same instinct as the **Committed response**: the framework records what happened rather than
+trusting a caller to declare it.
+
+Static assets get a **Derived validator** instead, on by default and with no flag, since a validator
+is advisory and the client decides whether to act on it. A disk mount uses modification time and
+size, which `fs.Stat` has already read. An embedded mount has no usable time, so its files are
+hashed (FNV-64a — not a security boundary) and the result cached per mount, for the process's
+lifetime. The rule states in one line: *a file that knows when it changed is validated by when it
+changed; one that does not is validated by what is in it.* Both forms are strong, because
+`net/http` requires a strong match for `If-Range` and a weak tag would silently cost every resumed
+download its ranges.
+
+## Considered options
+
+- **Caller-supplied validators, derived only for static (chosen)** — see above.
+- **Hashing the response body in core** — the familiar implementation, rejected above. It remains
+  available as a plugin to anyone who wants it, which is where the **Plugin complexity boundary**
+  puts a cost every user would otherwise pay.
+- **Size-only tags for embedded assets** — free, and wrong in the case embedded assets are for: a
+  same-length edit across a redeploy (`1.0.9` → `1.1.0`) would keep every client on the old copy
+  indefinitely.
+- **Hashing every static file on every request** — uniform, and a couple of milliseconds of CPU on
+  the hottest asset. The cache is what makes hashing viable, not an optimisation on top of it.
+- **A registration API (`app.ETag("/api/*", ...)`)** — a second way to say what a `Before` handler
+  already says, with its own path matching and lifecycle position, to save the user one line.
+- **A `StaticConfig` flag to disable derived validators** — configuration whose only purpose is
+  turning off correct behaviour that costs one hash per file. Addable later if someone turns up with
+  a reason.
+- **Leaving directories entirely to `http.FileServer`** — where they were. A directory holding an
+  `index.html` is serving a file, and delegating it meant the mount root, the most requested URL a
+  static site has, was the one file with no validator. It now goes through `Call` like any other.
+  What stays delegated is what genuinely belongs there: a generated listing, which has no validator
+  to derive short of hashing the body, and a directory reached without its trailing slash, which the
+  file server redirects.
+
+## Consequences
+
+- Existing static mounts start answering 304 to clients that revalidate. That is the bug fix, but it
+  is a behaviour change to responses users are already serving.
+- The static allocation budget rises to cover the derived tag and the header write.
+- The hash cache assumes a file system reporting no modification time cannot change beneath it. That
+  holds for `embed.FS`; a custom mutable `fs.FS` that also reports zero times would be served a stale
+  validator, and is documented as such.
+- `If-Match` and 412 are not implemented. Optimistic concurrency remains an open feature, and one
+  that must not be folded into `NotModified` when it arrives.
+- Freshness — `Cache-Control`, `Expires` — is a deliberate follow-up. A validator makes a
+  revalidation cheap; only freshness makes it unnecessary. Until then a client still pays a round
+  trip per asset to be told 304, which on a fast connection is the larger cost of the two.

--- a/etag.go
+++ b/etag.go
@@ -1,0 +1,85 @@
+package govalin
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/pkkummermo/govalin/internal/http/headers"
+)
+
+// NotModified sets the response ETag and reports whether the client already
+// holds this version of the resource.
+//
+// The tag is the caller's own validator — a row version, an updated_at, a digest
+// it already has — quoted if it is not already.
+//
+// A true return means the client's If-None-Match named this version and a 304 is
+// buffered. Producing no body is then an optimisation, not an obligation: one
+// written anyway is refused by net/http, so the client gets a correct 304 either
+// way.
+//
+// Only GET and HEAD are answered. On any other method If-None-Match is a
+// precondition asking a different question, and this does nothing.
+func (call *Call) NotModified(tag string) bool {
+	if call.req.Method != http.MethodGet && call.req.Method != http.MethodHead {
+		return false
+	}
+
+	etag := quoteETag(tag)
+	call.w.Header().Set(headers.ETag, etag)
+
+	if !etagMatches(call.req.Header.Get(headers.IfNoneMatch), etag) {
+		return false
+	}
+
+	call.Status(http.StatusNotModified)
+
+	return true
+}
+
+// quoteETag makes a caller's value a valid entity-tag. An unquoted one is a tag
+// no client will ever match back; one that carries its own quotes is left be.
+func quoteETag(tag string) string {
+	if strings.HasPrefix(tag, `"`) || strings.HasPrefix(tag, `W/"`) {
+		return tag
+	}
+
+	return `"` + tag + `"`
+}
+
+// etagMatches reports whether an If-None-Match header names the tag, by the weak
+// comparison RFC 9110 requires of it: W/"x" and "x" are the same version. Scans
+// in place, so the common case — no header at all — costs nothing.
+//
+// Only a comma outside a quoted tag separates the list. One inside is part of
+// the tag, and a caller's version string is quoted as it stands, so a comma in
+// one is not the exotic case it would be for a server that only sends digests.
+func etagMatches(ifNoneMatch string, etag string) bool {
+	if ifNoneMatch == "" {
+		return false
+	}
+
+	if strings.TrimSpace(ifNoneMatch) == "*" {
+		return true
+	}
+
+	target := strings.TrimPrefix(etag, "W/")
+	quoted := false
+	start := 0
+
+	for index := 0; index <= len(ifNoneMatch); index++ {
+		switch {
+		case index < len(ifNoneMatch) && ifNoneMatch[index] == '"':
+			quoted = !quoted
+		case index == len(ifNoneMatch) || (ifNoneMatch[index] == ',' && !quoted):
+			candidate := strings.TrimSpace(ifNoneMatch[start:index])
+			if strings.TrimPrefix(candidate, "W/") == target {
+				return true
+			}
+
+			start = index + 1
+		}
+	}
+
+	return false
+}

--- a/etag_test.go
+++ b/etag_test.go
@@ -1,0 +1,218 @@
+package govalin_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/pkkummermo/govalin"
+	"github.com/pkkummermo/govalin/govalintest"
+	"github.com/stretchr/testify/assert"
+)
+
+// revalidate sends a conditional request with the given If-None-Match header.
+func revalidate(t *testing.T, client *govalintest.Client, method string, path string, ifNoneMatch string) *http.Response {
+	t.Helper()
+
+	request, err := http.NewRequest(method, client.Host+path, nil)
+	if err != nil {
+		t.Fatalf("failed to build a conditional request: %v", err)
+	}
+
+	if ifNoneMatch != "" {
+		request.Header.Set("If-None-Match", ifNoneMatch)
+	}
+
+	return client.Do(request)
+}
+
+// etagApp serves one resource whose validator never changes, and whose handler
+// always writes a body.
+func etagApp(t *testing.T, tag string) *govalin.App {
+	t.Helper()
+
+	app := newTestApp()
+	app.Get("/resource", func(call *govalin.Call) {
+		if call.NotModified(tag) {
+			return
+		}
+
+		call.Text("the representation")
+	})
+
+	return app
+}
+
+func TestNotModifiedSendsValidator(t *testing.T) {
+	govalintest.Test(t, etagApp(t, "v3"), func(client *govalintest.Client) {
+		response := client.GetResponse("/resource")
+
+		assert.Equal(t, http.StatusOK, response.StatusCode, "Should serve the representation")
+		assert.Equal(t, `"v3"`, response.Header.Get("ETag"), "Should quote a bare tag")
+		assert.Equal(t, "the representation", readBody(t, response), "Should write the body")
+	})
+}
+
+func TestNotModifiedAnswersRevalidation(t *testing.T) {
+	govalintest.Test(t, etagApp(t, "v3"), func(client *govalintest.Client) {
+		response := revalidate(t, client, http.MethodGet, "/resource", `"v3"`)
+
+		assert.Equal(t, http.StatusNotModified, response.StatusCode, "Should answer 304 on a match")
+		assert.Empty(t, readBody(t, response), "Should send no body")
+		assert.Empty(t, response.Header.Get("Content-Type"), "Should describe no representation")
+		assert.Equal(t, `"v3"`, response.Header.Get("ETag"), "Should still name the version")
+	})
+}
+
+func TestNotModifiedServesAChangedResource(t *testing.T) {
+	govalintest.Test(t, etagApp(t, "v3"), func(client *govalintest.Client) {
+		response := revalidate(t, client, http.MethodGet, "/resource", `"v2"`)
+
+		assert.Equal(t, http.StatusOK, response.StatusCode, "Should serve a version the client lacks")
+		assert.Equal(t, "the representation", readBody(t, response), "Should write the body")
+	})
+}
+
+// TestNotModifiedComparesWeakly covers the comparison RFC 9110 requires of
+// If-None-Match: the weak form names the same version as the strong one, the
+// header may list several, and * names whatever the server has.
+func TestNotModifiedComparesWeakly(t *testing.T) {
+	govalintest.Test(t, etagApp(t, "v3"), func(client *govalintest.Client) {
+		for _, ifNoneMatch := range []string{`W/"v3"`, `"v1", "v3"`, `"v1",W/"v3"`, "*"} {
+			response := revalidate(t, client, http.MethodGet, "/resource", ifNoneMatch)
+
+			assert.Equal(
+				t,
+				http.StatusNotModified,
+				response.StatusCode,
+				"Should match the tag named by If-None-Match: %s", ifNoneMatch,
+			)
+		}
+	})
+}
+
+// TestNotModifiedMatchesATagContainingAComma covers the separator being a comma
+// outside a quoted tag rather than every comma: a caller's version string is
+// quoted as it stands, and splitting one in half would silently stop it matching.
+func TestNotModifiedMatchesATagContainingAComma(t *testing.T) {
+	govalintest.Test(t, etagApp(t, "sha,42"), func(client *govalintest.Client) {
+		served := client.GetResponse("/resource")
+		assert.Equal(t, `"sha,42"`, served.Header.Get("ETag"), "Should quote the tag as it stands")
+
+		for _, ifNoneMatch := range []string{`"sha,42"`, `"v1", "sha,42"`} {
+			response := revalidate(t, client, http.MethodGet, "/resource", ifNoneMatch)
+
+			assert.Equal(
+				t,
+				http.StatusNotModified,
+				response.StatusCode,
+				"Should match the tag named by If-None-Match: %s", ifNoneMatch,
+			)
+		}
+
+		unrelated := revalidate(t, client, http.MethodGet, "/resource", `"sha", "42"`)
+		assert.Equal(
+			t,
+			http.StatusOK,
+			unrelated.StatusCode,
+			"Should not match the halves of the tag listed separately",
+		)
+	})
+}
+
+func TestNotModifiedAnswersHead(t *testing.T) {
+	app := newTestApp()
+	app.Head("/resource", func(call *govalin.Call) {
+		if call.NotModified("v3") {
+			return
+		}
+
+		call.Text("the representation")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := revalidate(t, client, http.MethodHead, "/resource", `"v3"`)
+
+		assert.Equal(t, http.StatusNotModified, response.StatusCode, "Should revalidate a HEAD")
+	})
+}
+
+// TestNotModifiedLeavesUnsafeMethodsAlone covers the boundary of the feature:
+// on a write, If-None-Match is a precondition asking a different question, and
+// answering it 304 would silently drop the write.
+func TestNotModifiedLeavesUnsafeMethodsAlone(t *testing.T) {
+	app := newTestApp()
+	app.Post("/resource", func(call *govalin.Call) {
+		if call.NotModified("v3") {
+			return
+		}
+
+		call.Text("written")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := revalidate(t, client, http.MethodPost, "/resource", `"v3"`)
+
+		assert.Equal(t, http.StatusOK, response.StatusCode, "Should not 304 a write")
+		assert.Equal(t, "written", readBody(t, response), "Should perform the write")
+		assert.Empty(
+			t,
+			response.Header.Get("ETag"),
+			"Should not offer a validator a write could be conditioned on",
+		)
+	})
+}
+
+// TestNotModifiedWithoutTheEarlyReturn is the whole point of buffering the 304:
+// a handler that ignores the return value still sends a correct response, and
+// pays only in wasted work.
+func TestNotModifiedWithoutTheEarlyReturn(t *testing.T) {
+	app := newTestApp()
+	app.Get("/resource", func(call *govalin.Call) {
+		call.NotModified("v3")
+		call.Text("the representation")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := revalidate(t, client, http.MethodGet, "/resource", `"v3"`)
+
+		assert.Equal(t, http.StatusNotModified, response.StatusCode, "Should answer 304 regardless")
+		assert.Empty(t, readBody(t, response), "Should refuse the body the handler wrote")
+		assert.Empty(t, response.Header.Get("Content-Type"), "Should describe no representation")
+	})
+}
+
+// TestNotModifiedInBeforeHandler covers applying one validator to a group of
+// routes, which is the app-wide idiom: the short-circuit flushes the buffered
+// 304 and the not-found fallback leaves it alone.
+func TestNotModifiedInBeforeHandler(t *testing.T) {
+	app := newTestApp()
+	app.Before("/api/*", func(call *govalin.Call) bool {
+		return !call.NotModified("v3")
+	})
+	app.Get("/api/resource", func(call *govalin.Call) {
+		call.Text("the representation")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := revalidate(t, client, http.MethodGet, "/api/resource", `"v3"`)
+
+		assert.Equal(t, http.StatusNotModified, response.StatusCode, "Should short-circuit with a 304")
+		assert.Empty(t, readBody(t, response), "Should send no body")
+	})
+}
+
+func TestNotModifiedKeepsAnAlreadyValidTag(t *testing.T) {
+	tags := map[string]string{
+		`"v3"`:   `"v3"`,
+		`W/"v3"`: `W/"v3"`,
+		`v3`:     `"v3"`,
+	}
+
+	for tag, expected := range tags {
+		govalintest.Test(t, etagApp(t, tag), func(client *govalintest.Client) {
+			response := client.GetResponse("/resource")
+
+			assert.Equal(t, expected, response.Header.Get("ETag"), "Should send a valid entity-tag for %s", tag)
+		})
+	}
+}

--- a/perf_test.go
+++ b/perf_test.go
@@ -81,7 +81,7 @@ var allocationBudgets = []allocationBudget{
 	{
 		name:    "static file",
 		target:  "/static/sub/test.html",
-		allowed: 45,
+		allowed: 49,
 		build: func(app *App) {
 			app.Static("/static", func(_ *Call, staticConfig *StaticConfig) {
 				staticConfig.WithStaticPath("internal/testdata/static")

--- a/static.go
+++ b/static.go
@@ -3,6 +3,7 @@ package govalin
 import (
 	"errors"
 	"fmt"
+	"hash/fnv"
 	"io"
 	"io/fs"
 	"log/slog"
@@ -11,6 +12,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"sync"
 )
 
 // StaticConfig contains configuration for a static handler.
@@ -19,14 +21,16 @@ type StaticConfig struct {
 	spaMode    bool
 	staticPath string
 	fsContent  fs.FS
+	validators *sync.Map
 }
 
-func newStaticConfig() *StaticConfig {
+func newStaticConfig(validators *sync.Map) *StaticConfig {
 	return &StaticConfig{
 		hostPath:   "/",
 		spaMode:    false,
 		staticPath: "static",
 		fsContent:  nil,
+		validators: validators,
 	}
 }
 
@@ -58,6 +62,53 @@ func failStatic(call *Call, err error, message string) {
 	}
 }
 
+// validatorFor derives the validator for a static file: from when the file
+// changed if the file system knows, from what it contains if it does not. An
+// embedded file system reports no modification time, so content is all that is
+// left to identify a file by, and the hash is paid once for the mount's life.
+//
+// Both forms are strong tags, because net/http requires a strong match for
+// If-Range and a weak one would quietly cost every resumed download its ranges.
+func (config *StaticConfig) validatorFor(hostedFileSystem fs.FS, name string, fileInfo fs.FileInfo) string {
+	if !fileInfo.ModTime().IsZero() {
+		return fmt.Sprintf("%x-%x", fileInfo.ModTime().UnixNano(), fileInfo.Size())
+	}
+
+	if cached, isCached := config.validators.Load(name); isCached {
+		return cached.(string)
+	}
+
+	etag, hashErr := hashFile(hostedFileSystem, name)
+	if hashErr != nil {
+		// A validator we could not derive only means the client revalidates next time.
+		slog.Debug("Failed to hash a static file for its validator", "name", name, "err", hashErr)
+
+		return ""
+	}
+
+	config.validators.Store(name, etag)
+
+	return etag
+}
+
+// hashFile derives a validator from a file's content, on its own handle so the
+// one being served keeps its position.
+func hashFile(hostedFileSystem fs.FS, name string) (string, error) {
+	file, openErr := hostedFileSystem.Open(name)
+	if openErr != nil {
+		return "", openErr
+	}
+	defer func() { _ = file.Close() }()
+
+	// Not a security boundary: this names a version, it does not attest to one.
+	hash := fnv.New64a()
+	if _, copyErr := io.Copy(hash, file); copyErr != nil {
+		return "", copyErr
+	}
+
+	return fmt.Sprintf("%x", hash.Sum64()), nil
+}
+
 // serveFile sends a file from the mounted file system through Call, so the
 // response stays inside the govalin lifecycle and Range requests are answered.
 func (config *StaticConfig) serveFile(call *Call, hostedFileSystem fs.FS, name string) error {
@@ -70,6 +121,12 @@ func (config *StaticConfig) serveFile(call *Call, hostedFileSystem fs.FS, name s
 	fileInfo, statErr := file.Stat()
 	if statErr != nil {
 		return statErr
+	}
+
+	// Both sinks below revalidate the same way, so the check happens here rather
+	// than in http.ServeContent, which only the seekable one reaches.
+	if etag := config.validatorFor(hostedFileSystem, name, fileInfo); etag != "" && call.NotModified(etag) {
+		return nil
 	}
 
 	// Range support needs to seek. Every file system govalin mounts (an os.Root
@@ -149,14 +206,24 @@ Are you sure it exists and is readable on the given path: '%s'`, config.staticPa
 		call.Error(statErr)
 		return
 	case fileInfo.IsDir():
-		// A directory is the file server's job: it owns the trailing-slash
-		// canonicalization and the directory index.
-		http.StripPrefix(
-			config.hostPath,
-			http.FileServer(http.FS(hostedFileSystem)),
-		).ServeHTTP(*call.Raw.W, call.Raw.Req)
+		// A directory holding an index.html is serving a file, and goes through
+		// Call like any other so that it carries a validator — the mount root is
+		// the most requested URL a static site has. What is left is the file
+		// server's: a generated listing, which has no validator to derive, and a
+		// directory reached without its trailing slash, which it redirects.
+		indexName := path.Join(name, indexFileName)
+		_, indexErr := fs.Stat(hostedFileSystem, indexName)
 
-		return
+		if indexErr != nil || !strings.HasSuffix(call.URL().Path, "/") {
+			http.StripPrefix(
+				config.hostPath,
+				http.FileServer(http.FS(hostedFileSystem)),
+			).ServeHTTP(*call.Raw.W, call.Raw.Req)
+
+			return
+		}
+
+		name = indexName
 	}
 
 	failStatic(
@@ -209,8 +276,12 @@ func (server *App) Static(path string, staticHandlerFunc StaticHandlerFunc) *App
 	normalizedPath := strings.TrimRight(path, "/*")
 	wildcardPath := normalizedPath + "/*"
 
+	// The config is rebuilt per request, so hashed validators live out here with
+	// the mount they describe — which is what makes the file name a sufficient key.
+	validators := &sync.Map{}
+
 	staticGetHandler := func(call *Call) {
-		internalConfig := newStaticConfig()
+		internalConfig := newStaticConfig(validators)
 		internalConfig.HostPath(normalizedPath)
 
 		staticHandlerFunc(call, internalConfig)

--- a/static_test.go
+++ b/static_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/fstest"
 
 	"github.com/pkkummermo/govalin"
 	"github.com/pkkummermo/govalin/govalintest"
@@ -167,6 +168,168 @@ func TestStaticServesRanges(t *testing.T) {
 				mount,
 			)
 		}
+	})
+}
+
+// TestStaticDerivesValidators covers both mount kinds getting a validator
+// without being asked: a disk mount from modification time and size, an
+// embedded one — which reports no modification time at all — from its content.
+func TestStaticDerivesValidators(t *testing.T) {
+	staticRoot, _ := fs.Sub(staticTestFiles, "internal/testdata/static")
+
+	app := newTestApp()
+	app.Static("/fs", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithFS(staticRoot)
+	})
+	app.Static("/static", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithStaticPath("internal/testdata/static")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		for _, mount := range []string{"/fs", "/static"} {
+			served := client.GetResponse(mount + "/index.html")
+			etag := served.Header.Get("ETag")
+
+			assert.NotEmpty(t, etag, "A file served from %s should carry a validator", mount)
+			assert.Contains(t, readBody(t, served), "Hello world", "%s should serve the file", mount)
+
+			revalidated := revalidate(t, client, http.MethodGet, mount+"/index.html", etag)
+			assert.Equal(
+				t,
+				http.StatusNotModified,
+				revalidated.StatusCode,
+				"Revalidating a file on %s should be answered with a 304",
+				mount,
+			)
+			assert.Empty(t, readBody(t, revalidated), "A 304 from %s should carry no body", mount)
+		}
+	})
+}
+
+// TestStaticDerivesValidatorsForDirectoryIndexes covers the URL a static site is
+// asked for most: the mount root, and any directory holding an index.html. These
+// used to be handed to http.FileServer, which sends no validator, so the SPA
+// shell on an embedded mount was the one file that could not be revalidated.
+func TestStaticDerivesValidatorsForDirectoryIndexes(t *testing.T) {
+	bundle := fstest.MapFS{"index.html": &fstest.MapFile{Data: []byte("shell")}}
+
+	app := newTestApp()
+	app.Static("/fs", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithFS(bundle)
+	})
+	app.Static("/static", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithStaticPath("internal/testdata/static")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		for _, mountRoot := range []string{"/fs/", "/static/"} {
+			served := client.GetResponse(mountRoot)
+			etag := served.Header.Get("ETag")
+
+			assert.NotEmpty(t, etag, "%s should carry a validator", mountRoot)
+
+			revalidated := revalidate(t, client, http.MethodGet, mountRoot, etag)
+			assert.Equal(
+				t,
+				http.StatusNotModified,
+				revalidated.StatusCode,
+				"Revalidating %s should be answered with a 304",
+				mountRoot,
+			)
+		}
+	})
+}
+
+// TestStaticLeavesTheFileServerItsWork pins the other half of that split: a
+// directory with no index.html is still the file server's to list, and a
+// directory reached without its trailing slash is still its to redirect.
+func TestStaticLeavesTheFileServerItsWork(t *testing.T) {
+	indexless := fstest.MapFS{"notes/readme.txt": &fstest.MapFile{Data: []byte("notes")}}
+
+	app := newTestApp()
+	app.Static("/listing", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithFS(indexless)
+	})
+	app.Static("/static", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithStaticPath("internal/testdata/static")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		client.HTTP().CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+
+		listing := client.GetResponse("/listing/")
+		assert.Equal(t, 200, listing.StatusCode, "A mount with no index should still be listed")
+		assert.Contains(t, readBody(t, listing), "notes", "The listing should name the directory's entries")
+		assert.Empty(t, listing.Header.Get("ETag"), "A generated listing has no validator to derive")
+
+		redirect := client.GetResponse("/static/sub")
+		assert.Equal(
+			t,
+			http.StatusMovedPermanently,
+			redirect.StatusCode,
+			"A directory without its trailing slash should still redirect",
+		)
+	})
+}
+
+// TestStaticValidatorFollowsContentWithoutAClock is the reason an embedded file
+// is hashed rather than measured. Two builds of a bundle can differ in content
+// at identical size — a version bump of the same length — and with no
+// modification time to fall back on, a size-derived tag would keep every client
+// on the old copy indefinitely.
+func TestStaticValidatorFollowsContentWithoutAClock(t *testing.T) {
+	etagFor := func(t *testing.T, content string) string {
+		t.Helper()
+
+		bundle := fstest.MapFS{"app.js": &fstest.MapFile{Data: []byte(content)}}
+
+		app := newTestApp()
+		app.Static("/assets", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+			staticConfig.WithFS(bundle)
+		})
+
+		var etag string
+
+		govalintest.Test(t, app, func(client *govalintest.Client) {
+			etag = client.GetResponse("/assets/app.js").Header.Get("ETag")
+		})
+
+		return etag
+	}
+
+	before := etagFor(t, `const version = "1.0.9"`)
+	after := etagFor(t, `const version = "1.1.0"`)
+
+	assert.NotEmpty(t, before, "An embedded file should carry a validator despite having no modification time")
+	assert.NotEqual(t, before, after, "A same-length change should change the validator")
+}
+
+// TestStaticValidatorKeepsRangesResumable pins the reason derived validators are
+// strong: net/http requires a strong match for If-Range, so a weak tag would
+// turn every resumed download back into a full one.
+func TestStaticValidatorKeepsRangesResumable(t *testing.T) {
+	app := newTestApp()
+	app.Static("/static", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithStaticPath("internal/testdata/static")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		full := readBody(t, client.GetResponse("/static/index.html"))
+		etag := client.GetResponse("/static/index.html").Header.Get("ETag")
+
+		request, err := http.NewRequest(http.MethodGet, client.Host+"/static/index.html", nil)
+		if err != nil {
+			t.Fatalf("failed to build a ranged request: %v", err)
+		}
+
+		request.Header.Set("Range", "bytes=0-4")
+		request.Header.Set("If-Range", etag)
+
+		partial := client.Do(request)
+		assert.Equal(t, 206, partial.StatusCode, "A resume against the served validator should stay ranged")
+		assert.Equal(t, full[:5], readBody(t, partial), "A 206 should carry exactly the requested bytes")
 	})
 }
 


### PR DESCRIPTION
## What

Govalin answered no conditional request of its own. `ServeContent` inherits `If-None-Match` handling from `net/http`, but only against an `ETag` a handler had already set — and there was no way to set one. Embedded static mounts were worse off still: `embed.FS` reports the zero modification time, so `Last-Modified` was omitted and an embedded bundle was uncacheable outright.

Two things land:

- **`call.NotModified(tag) bool`** — sets the `ETag`, compares `If-None-Match` by the weak comparison RFC 9110 requires, and buffers a 304 on a match.
- **Derived validators for static mounts**, on by default. A disk mount uses modification time and size, which `fs.Stat` has already read; a file system with no modification time has its files hashed instead, once each for the mount's lifetime.

## Why this shape

The tag is the caller's, out of something it already knows — a row version, a digest. **Core does not hash response bodies**, which is what every other framework's ETag plugin does. It inverts the point of the feature: the handler has already run the query and marshalled the result before the framework could discover the client needed none of it. It also fights the write-through response model of ADR 0007 and puts a buffer allocation on every request against the ADR 0008 gate.

A match buffers the 304 rather than committing it, so the return value is permission to skip work rather than a correctness obligation — a handler that ignores it and writes a body anyway still sends a correct empty 304, because `net/http` refuses a body the status forbids. Same instinct as `Committed response`: the framework records what happened instead of trusting a caller to declare it.

Size alone would not do for embedded assets: a same-length change across a redeploy (`1.0.9` -> `1.1.0`) would keep every client on the old copy. Both derived forms are strong tags, because `net/http` requires a strong match for `If-Range` and a weak one would quietly cost every resumed download its ranges.

Reasoning recorded in `docs/adr/0009-user-supplied-cache-validators.md`; vocabulary in `CONTEXT.md`.

## Notes

- Static allocation budget rises 45 -> 49, per ADR 0008, with the reason in the commit that needs it.
- Existing static mounts start answering 304 to clients that revalidate. That is the fix, but it is a behaviour change to responses already being served.
- Freshness (`Cache-Control`, `Expires`) is a deliberate non-goal — #83. A validator makes a revalidation cheap; only freshness makes it unnecessary.
- Found while testing, unrelated and not fixed here: HEAD is not routed to a GET handler — #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)