### PR TITLE
fix(routing): serve HEAD from the GET handler

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -256,6 +256,13 @@ to. The 304 is buffered the moment the match is found, so a handler that produce
 sends a correct empty 304 — it has wasted only its own work.
 _Avoid_: correctness that depends on the caller reading a return value, a body inside a 304
 
+**Implied HEAD**:
+A HEAD answered by the route's GET handler, because HEAD is GET without a body. A handler registered
+for HEAD replaces it wherever it sits in the route table — that is how a route buys the right to skip
+producing a body, since net/http discards the one an implied HEAD writes. OPTIONS gets no
+equivalent: its response is not a representation of the resource, and CORS already owns that path.
+_Avoid_: 404 on a path that has a GET, an implied HEAD shadowing a registered one, GET-derived OPTIONS
+
 ## Relationships
 
 - A **Race-clean build** is a required outcome of the **Stability gate**
@@ -308,6 +315,10 @@ _Avoid_: correctness that depends on the caller reading a return value, a body i
 - A **Revalidation short-circuit** buffers 304 like any other **Buffered status**, so **Status flush** and **Committed response** govern it unchanged
 - A 304 carries no representation, so the **Status flush** drops the headers that describe one
 - A **Strong validator** is what keeps **Ranged content** resumable across a revalidation
+- An **Implied HEAD** is what lets a static mount answer a cache probe: the **Derived validator** and
+  the length are already on the response its GET handler produces
+- An **Implied HEAD** is logged as the HEAD it is; that a GET handler answered it is routing, not
+  something the client did
 
 ## Example dialogue
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ func main() {
 }
 ```
 
+A route registered with `Get` also answers `HEAD`, as HTTP defines it: the handler runs and its body
+is dropped. Register `Head` explicitly on a route that can answer without producing one, and it wins.
+
 ## Serving files and large bodies
 
 `Text`, `HTML` and `JSON` are for bodies that fit in memory. For anything bigger, `Call` streams:

--- a/etag_test.go
+++ b/etag_test.go
@@ -120,16 +120,7 @@ func TestNotModifiedMatchesATagContainingAComma(t *testing.T) {
 }
 
 func TestNotModifiedAnswersHead(t *testing.T) {
-	app := newTestApp()
-	app.Head("/resource", func(call *govalin.Call) {
-		if call.NotModified("v3") {
-			return
-		}
-
-		call.Text("the representation")
-	})
-
-	govalintest.Test(t, app, func(client *govalintest.Client) {
+	govalintest.Test(t, etagApp(t, "v3"), func(client *govalintest.Client) {
 		response := revalidate(t, client, http.MethodHead, "/resource", `"v3"`)
 
 		assert.Equal(t, http.StatusNotModified, response.StatusCode, "Should revalidate a HEAD")

--- a/server.go
+++ b/server.go
@@ -180,7 +180,8 @@ func (server *App) After(path string, afterFunc AfterFunc) {
 // Add a GET handler
 //
 // Add a GET handler based on where you are in a hierarchy composed from
-// other method handlers or route handlers.
+// other method handlers or route handlers. It also answers HEAD requests for
+// the path, unless a HEAD handler is registered for it.
 func (server *App) Get(path string, handler HandlerFunc) *App {
 	server.addMethod(http.MethodGet, server.currentFragment+path, handler)
 	return server
@@ -234,7 +235,8 @@ func (server *App) Options(path string, handler HandlerFunc) *App {
 // Add a HEAD handler
 //
 // Add a HEAD handler based on where you are in a hierarchy composed from
-// other method handlers or route handlers.
+// other method handlers or route handlers. It takes precedence over the GET
+// handler that would otherwise answer the HEAD.
 func (server *App) Head(path string, handler HandlerFunc) *App {
 	server.addMethod(http.MethodHead, server.currentFragment+path, handler)
 	return server
@@ -388,18 +390,37 @@ func (server *App) matchBeforeHandlers(call *Call) bool {
 }
 
 func (server *App) matchHandlers(call *Call) {
+	if server.callHandlerByMethod(call, call.Method()) {
+		return
+	}
+
+	// HEAD is GET without a body (RFC 9110 §9.3.2), so a path govalin has a GET
+	// for answers a HEAD with it — net/http drops the body the handler writes. A
+	// second pass rather than a fallback inside the lookup, so that a handler
+	// registered for HEAD wins wherever it sits in the route table.
+	if call.Method() == http.MethodHead {
+		server.callHandlerByMethod(call, http.MethodGet)
+	}
+}
+
+// callHandlerByMethod runs the first registered handler for the method whose
+// path matches the request, and reports whether the request was handled.
+func (server *App) callHandlerByMethod(call *Call, method string) bool {
 	for _, pathHandler := range server.pathHandlers {
 		if call.bypassLifecycle {
-			return
+			return true
 		}
 
-		if pathHandler.GetHandlerByMethod(call.Method()) != nil && pathHandler.PathMatcher.MatchesURL(call.URL().Path) {
-			handler := pathHandler.GetHandlerByMethod(call.Method())
+		handler := pathHandler.GetHandlerByMethod(method)
+		if handler != nil && pathHandler.PathMatcher.MatchesURL(call.URL().Path) {
 			call.pathParams = pathHandler.PathMatcher.PathParams(call.URL().Path)
 			handler(call)
-			break
+
+			return true
 		}
 	}
+
+	return false
 }
 
 func (server *App) matchAfterHandlers(call *Call) {

--- a/server_test.go
+++ b/server_test.go
@@ -3,6 +3,7 @@ package govalin_test
 import (
 	"fmt"
 	"net"
+	"net/http"
 	"net/url"
 	"testing"
 	"time"
@@ -159,6 +160,84 @@ func TestHead(t *testing.T) {
 			response.Header.Get("govalin-header"),
 			"Should create head endpoint",
 		)
+	})
+}
+
+// TestHeadIsServedByTheGetHandler covers HEAD as GET without a body (RFC 9110
+// §9.3.2): a route registered with Get answers it with the headers it would have
+// sent, and net/http drops the body the handler wrote.
+func TestHeadIsServedByTheGetHandler(t *testing.T) {
+	app := newTestApp()
+	app.Get("/resource", func(call *govalin.Call) {
+		call.Header("govalin-header", "govalin")
+		call.Text("the representation")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.HeadResponse("/resource")
+
+		assert.Equal(t, http.StatusOK, response.StatusCode, "Should serve HEAD from the GET handler")
+		assert.Equal(t, "govalin", response.Header.Get("govalin-header"), "Should send the GET handler's headers")
+		assert.Equal(
+			t,
+			int64(len("the representation")),
+			response.ContentLength,
+			"Should describe the body a GET would have sent",
+		)
+		assert.Empty(t, readBody(t, response), "Should send no body")
+	})
+}
+
+// TestHeadHandlerWinsOverGet covers the fallback being only a fallback: a route
+// that answers HEAD itself keeps doing so.
+func TestHeadHandlerWinsOverGet(t *testing.T) {
+	app := newTestApp()
+	app.Get("/resource", func(call *govalin.Call) {
+		call.Header("served-by", "get")
+	})
+	app.Head("/resource", func(call *govalin.Call) {
+		call.Header("served-by", "head")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.HeadResponse("/resource")
+		defer func() { _ = response.Body.Close() }()
+
+		assert.Equal(t, "head", response.Header.Get("served-by"), "Should prefer the HEAD handler")
+	})
+}
+
+// TestHeadHandlerWinsOverAnEarlierGet covers the fallback not shadowing an
+// explicit HEAD registered elsewhere. Routes are matched in registration order,
+// so a wildcard GET — a static mount is one — would otherwise claim a HEAD the
+// route behind it answers itself.
+func TestHeadHandlerWinsOverAnEarlierGet(t *testing.T) {
+	app := newTestApp()
+	app.Get("/resource/*", func(call *govalin.Call) {
+		call.Header("served-by", "get")
+	})
+	app.Head("/resource/cheap", func(call *govalin.Call) {
+		call.Header("served-by", "head")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.HeadResponse("/resource/cheap")
+		defer func() { _ = response.Body.Close() }()
+
+		assert.Equal(t, "head", response.Header.Get("served-by"), "Should prefer the HEAD handler wherever it is registered")
+	})
+}
+
+// TestHeadWithoutAGetIsNotFound covers the fallback not inventing a route: a
+// path with no GET handler answers a HEAD the same way it answers a GET.
+func TestHeadWithoutAGetIsNotFound(t *testing.T) {
+	app := newTestApp()
+	app.Post("/resource", func(call *govalin.Call) {
+		call.Text("posted")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		assert.Equal(t, http.StatusNotFound, client.HeadStatus("/resource"), "Should not answer a HEAD it has no GET for")
 	})
 }
 

--- a/static_test.go
+++ b/static_test.go
@@ -171,6 +171,47 @@ func TestStaticServesRanges(t *testing.T) {
 	})
 }
 
+// TestStaticServesHead covers what a static mount answers a cache probe: the
+// file server underneath already suppresses the body and sends the headers that
+// describe the file, so only the route lookup stood between a HEAD and them.
+func TestStaticServesHead(t *testing.T) {
+	staticRoot, _ := fs.Sub(staticTestFiles, "internal/testdata/static")
+
+	app := newTestApp()
+	app.Static("/fs", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithFS(staticRoot)
+	})
+	app.Static("/static", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithStaticPath("internal/testdata/static")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		for _, mount := range []string{"/fs", "/static"} {
+			served := client.GetResponse(mount + "/index.html")
+			body := readBody(t, served)
+
+			headed := client.HeadResponse(mount + "/index.html")
+
+			assert.Equal(t, http.StatusOK, headed.StatusCode, "A HEAD on %s should be served", mount)
+			assert.Equal(
+				t,
+				served.Header.Get("ETag"),
+				headed.Header.Get("ETag"),
+				"A HEAD on %s should carry the same validator as the GET",
+				mount,
+			)
+			assert.Equal(
+				t,
+				int64(len(body)),
+				headed.ContentLength,
+				"A HEAD on %s should describe the length of the file",
+				mount,
+			)
+			assert.Empty(t, readBody(t, headed), "A HEAD on %s should carry no body", mount)
+		}
+	})
+}
+
 // TestStaticDerivesValidators covers both mount kinds getting a validator
 // without being asked: a disk mount from modification time and size, an
 // embedded one — which reports no modification time at all — from its content.


### PR DESCRIPTION
HEAD is GET without a body (RFC 9110 §9.3.2), but the route lookup matched the method exactly, so a path registered with `Get` answered 404 to a HEAD — and no static file answered one at all, since `Static` registers only GET.

The fallback is a second pass over the route table rather than part of the per-route lookup. Routes match in registration order, so folding it into the lookup would let a wildcard GET — a static mount is one — claim a HEAD that a route behind it registered a handler for; `Static("/fs")` plus `Head("/fs/index.html")` made the explicit handler unreachable. As a second pass, an explicit `Head` wins wherever it sits, so a route that can answer without producing a body keeps that option.

The two open decisions from the issue, recorded as **Implied HEAD** in `CONTEXT.md`: the access log keeps reporting the method the client sent, and OPTIONS gets no equivalent fallback — its response is not a representation, and CORS owns that path.

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)