### PR TITLE
fix(static): give the trailing slash below a static mount its meaning

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -205,6 +205,27 @@ a name that leaves that directory — including through a symlink — is refused
 comparing cleaned path strings.
 _Avoid_: prefix-comparison containment, cleaned-path-as-proof, stat-then-open resolution
 
+**Trailing-slash directory claim**:
+A trailing slash on a static URL is the request claiming the name addresses a directory. The name
+handed to the file system never carries one, because `io/fs` refuses it, so the claim is answered
+separately: a directory serves its index or its listing, and a name that turns out to hold a file is
+redirected to its slashless URL.
+_Avoid_: a trailing slash reaching an fs name, one file served at both spellings
+
+**Refused name**:
+A name the mounted file system will not resolve, for any reason it gives — a `..` segment, a symlink
+leaving the root, a directory it may not read. Answered as a missing file, deliberately
+indistinguishable from one, because an answer that varied with the reason tells a prober which names
+are there. The bluntness is the point, which is why a name govalin malformed itself must never reach
+it: there is nothing downstream that can tell the two apart.
+_Avoid_: 500 for a name that escapes the root, the reason a name failed visible in the response
+
+**SPA fallback**:
+What a mount in SPA mode answers with when a URL addresses no file it holds: the shell, on the
+grounds that the route belongs to the client. A directory is not a file it holds, so the fallback
+covers that too and a SPA bundle is never enumerated.
+_Avoid_: a generated listing of a SPA bundle, 404 for a client-side route
+
 **Request-controlled value**:
 A value the client alone decides — request path, `User-Agent`. Unbounded in length and unconstrained
 in content until govalin bounds it.
@@ -301,6 +322,9 @@ _Avoid_: correctness that depends on the caller reading a return value, a body i
 - The **Body size limit** and the **Multipart size limit** bound what the server accepts; the **Multipart memory budget** bounds only where an accepted upload is stored
 - **Declared-length rejection** is the first enforcement step for every limit, with the limiter as the fallback for bodies of unknown length
 - **Root-confined static access** replaces path-string containment: the static mount is a resource the OS confines, not a prefix the framework checks
+- A **Trailing-slash directory claim** carries **Canonical static mount URL** below the mount root: one spelling serves the resource, the other redirects to it
+- A **Refused name** is where **Root-confined static access** stops being visible: what the OS refused is not reported back, only that nothing was found
+- A **SPA fallback** takes precedence over a generated listing, but never over a **Trailing-slash directory claim**: a spelling that disagrees with the file system is redirected in either mode
 - A **Request-controlled value** reaching a log becomes a **Log-safe value** first; there is no path from a header to a log sink that skips it
 - The **Correlation ID** is the deliberate exception: client-chosen and logged verbatim, because propagating it is the feature
 - **Cache validation** is answered on safe methods only; the same header on an unsafe method is a precondition, and out of scope

--- a/static.go
+++ b/static.go
@@ -142,6 +142,16 @@ func (config *StaticConfig) serveFile(call *Call, hostedFileSystem fs.FS, name s
 	return nil
 }
 
+// serveWithFileServer hands the request to net/http for the two jobs govalin
+// leaves it: generating a directory listing, and redirecting a URL whose
+// trailing slash disagrees with what the name it addresses holds.
+func (config *StaticConfig) serveWithFileServer(call *Call, hostedFileSystem fs.FS) {
+	http.StripPrefix(
+		config.hostPath,
+		http.FileServer(http.FS(hostedFileSystem)),
+	).ServeHTTP(*call.Raw.W, call.Raw.Req)
+}
+
 func (config *StaticConfig) handle(call *Call) {
 	isFS := config.fsContent != nil
 
@@ -168,9 +178,14 @@ Are you sure it exists and is readable on the given path: '%s'`, config.staticPa
 		hostedFileSystem = root.FS()
 	}
 
+	// A trailing slash is the URL claiming the name addresses a directory. io/fs
+	// refuses a name carrying one, so it is kept here as a claim to answer
+	// against what the name turns out to hold, and dropped from the name itself.
+	namedAsDirectory := strings.HasSuffix(mountPath, "/")
+
 	// An fs.FS addresses entries relative to its root, and names the root
 	// directory itself "." rather than the empty string.
-	name := strings.TrimPrefix(mountPath, "/")
+	name := strings.TrimRight(strings.TrimPrefix(mountPath, "/"), "/")
 	if name == "" {
 		name = "."
 	}
@@ -180,6 +195,8 @@ Are you sure it exists and is readable on the given path: '%s'`, config.staticPa
 
 	var pathErr *fs.PathError
 
+	// A name the file system refuses is a missing file here: a '..' segment or an
+	// escaping symlink must not answer differently from a name that isn't there.
 	isNotFoundError := errors.Is(statErr, fs.ErrNotExist) || errors.As(statErr, &pathErr)
 
 	// Serve index if:
@@ -205,20 +222,27 @@ Are you sure it exists and is readable on the given path: '%s'`, config.staticPa
 		call.Status(http.StatusInternalServerError)
 		call.Error(statErr)
 		return
+	case fileInfo.IsDir() != namedAsDirectory:
+		// The URL's claim and the file system disagree, in either direction: the
+		// file server redirects to the spelling that addresses what is there, so
+		// that neither is served at both.
+		config.serveWithFileServer(call, hostedFileSystem)
+
+		return
 	case fileInfo.IsDir():
 		// A directory holding an index.html is serving a file, and goes through
 		// Call like any other so that it carries a validator — the mount root is
-		// the most requested URL a static site has. What is left is the file
-		// server's: a generated listing, which has no validator to derive, and a
-		// directory reached without its trailing slash, which it redirects.
+		// the most requested URL a static site has. Without one, the generated
+		// listing is the file server's, having no validator to derive.
 		indexName := path.Join(name, indexFileName)
-		_, indexErr := fs.Stat(hostedFileSystem, indexName)
-
-		if indexErr != nil || !strings.HasSuffix(call.URL().Path, "/") {
-			http.StripPrefix(
-				config.hostPath,
-				http.FileServer(http.FS(hostedFileSystem)),
-			).ServeHTTP(*call.Raw.W, call.Raw.Req)
+		if _, indexErr := fs.Stat(hostedFileSystem, indexName); indexErr != nil {
+			// Except on a SPA mount, which answers everything that is not a file
+			// with the shell, so its bundle is nobody's to enumerate.
+			if config.spaMode {
+				config.serveIndex(call, hostedFileSystem)
+			} else {
+				config.serveWithFileServer(call, hostedFileSystem)
+			}
 
 			return
 		}

--- a/static.go
+++ b/static.go
@@ -199,10 +199,9 @@ Are you sure it exists and is readable on the given path: '%s'`, config.staticPa
 	// escaping symlink must not answer differently from a name that isn't there.
 	isNotFoundError := errors.Is(statErr, fs.ErrNotExist) || errors.As(statErr, &pathErr)
 
-	// Serve index if:
-	// 1. If path is empty (slash root)
-	// 2. if SPA mode is enabled, and if the file doesn't exist
-	if mountPath == "" || (config.spaMode && isNotFoundError) {
+	// A name that resolves to nothing is a client-side route on a SPA mount, so
+	// the shell answers it.
+	if config.spaMode && isNotFoundError {
 		config.serveIndex(call, hostedFileSystem)
 		return
 	}

--- a/static_test.go
+++ b/static_test.go
@@ -274,6 +274,120 @@ func TestStaticLeavesTheFileServerItsWork(t *testing.T) {
 	})
 }
 
+// TestStaticResolvesADirectoryBelowTheMount covers the round trip a directory is
+// reached by: the file server redirects '/sub' to '/sub/', and that destination
+// has to resolve. The name handed to the file system is derived from the URL,
+// and io/fs refuses one with a trailing slash, so the redirect used to point at
+// a 404 and every directory below a mount was unreachable.
+func TestStaticResolvesADirectoryBelowTheMount(t *testing.T) {
+	bundle := fstest.MapFS{
+		"sub/index.html":   &fstest.MapFile{Data: []byte("Sub hello world")},
+		"notes/readme.txt": &fstest.MapFile{Data: []byte("notes")},
+	}
+
+	app := newTestApp()
+	app.Static("/fs", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithFS(bundle)
+	})
+	app.Static("/static", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithStaticPath("internal/testdata/static")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		indexed := client.GetResponse("/fs/sub/")
+		assert.Equal(t, 200, indexed.StatusCode, "A directory holding an index.html should serve it")
+		assert.Contains(t, readBody(t, indexed), "Sub hello world", "The directory's own index should be the body")
+		assert.NotEmpty(
+			t,
+			indexed.Header.Get("ETag"),
+			"A directory index goes through Call, so it carries a validator like any other file",
+		)
+
+		listed := client.GetResponse("/fs/notes/")
+		assert.Equal(t, 200, listed.StatusCode, "A directory without an index.html should be listed")
+		assert.Contains(t, readBody(t, listed), "readme.txt", "The listing should name the directory's entries")
+
+		// The redirect the file server answers '/sub' with, followed by the client.
+		followed := client.GetResponse("/static/sub")
+		assert.Equal(
+			t,
+			200,
+			followed.StatusCode,
+			"The redirect from a directory reached without its trailing slash has to land somewhere",
+		)
+		assert.Contains(t, readBody(t, followed), "test.html", "It lands on the listing of the directory it named")
+	})
+}
+
+// TestStaticRedirectsAFileAskedForAsADirectory pins the other half of what a
+// trailing slash means. It names a directory, so a name that turns out to hold a
+// file is answered with the redirect to its canonical URL rather than served at
+// both spellings.
+func TestStaticRedirectsAFileAskedForAsADirectory(t *testing.T) {
+	app := newTestApp()
+	app.Static("/static", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithStaticPath("internal/testdata/static")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		client.HTTP().CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+
+		response := client.GetResponse("/static/sub/test.html/?page=2")
+		assert.Equal(
+			t,
+			http.StatusMovedPermanently,
+			response.StatusCode,
+			"A file asked for as a directory should be redirected, not served at a second URL",
+		)
+
+		location, locationErr := response.Location()
+		assert.Nil(t, locationErr, "The redirect should carry a location")
+		assert.Equal(t, "/static/sub/test.html", location.Path, "It should point at the file's canonical URL")
+		assert.Equal(t, "page=2", location.RawQuery, "A framework redirect keeps the query it was asked with")
+	})
+}
+
+// TestStaticSPAModeResolvesDirectories covers where the unreachable directory
+// was worst: SPA mode answered the shell with a 200, so a URL that named a real
+// directory failed to resolve without anything saying so. What a SPA mount must
+// not start doing, now that directories resolve, is enumerate its own bundle.
+func TestStaticSPAModeResolvesDirectories(t *testing.T) {
+	bundle := fstest.MapFS{
+		"index.html":       &fstest.MapFile{Data: []byte("shell")},
+		"docs/index.html":  &fstest.MapFile{Data: []byte("docs index")},
+		"assets/app.js":    &fstest.MapFile{Data: []byte("bundled")},
+		"assets/vendor.js": &fstest.MapFile{Data: []byte("vendored")},
+	}
+
+	app := newTestApp()
+	app.Static("/spa", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.
+			WithFS(bundle).
+			EnableSPAMode(true)
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		assert.Contains(
+			t,
+			client.Get("/spa/docs/"),
+			"docs index",
+			"A directory that exists should resolve, not fall through to the SPA shell",
+		)
+		assert.Contains(
+			t,
+			client.Get("/spa/no/such/path"),
+			"shell",
+			"A name that resolves to nothing should still get the SPA shell",
+		)
+
+		listing := client.Get("/spa/assets/")
+		assert.Contains(t, listing, "shell", "A directory a SPA mount cannot serve should get the shell")
+		assert.NotContains(t, listing, "vendor.js", "A SPA mount should not enumerate its own bundle")
+	})
+}
+
 // TestStaticValidatorFollowsContentWithoutAClock is the reason an embedded file
 // is hashed rather than measured. Two builds of a bundle can differ in content
 // at identical size — a version bump of the same length — and with no


### PR DESCRIPTION
Closes #85.

Every URL with a trailing slash below a static mount answered 404, including `sub/` — the destination of the redirect the file server answers `/static/sub` with. The FS name was derived by trimming the mount prefix, so `/static/sub/` asked `io/fs` for `"sub/"`, a name it refuses; the not-found classifier read the refusal as a missing file. Directories below a mount were unreachable, and in SPA mode the failure was silent, since the shell answered a URL that had not resolved.

The slash is now dropped from the name and kept as what the request claimed. That leaves one rule covering both directions of disagreement — `fileInfo.IsDir() != namedAsDirectory` — so a spelling that does not match what the file system holds is redirected to the one that does, rather than served at both. The `/sub` → `sub/` redirect is unchanged; `/index.html/` → `index.html` is new, and is what keeps the fix from introducing a second URL per file.

**On the issue's open question** — whether an invalid name should keep being reported as missing: it should. `os.Root`'s "path escapes from parent" is neither `ErrNotExist` nor `ErrInvalid`, only a bare `*fs.PathError`, so the blunt `errors.As` clause is the only thing making an escaping symlink indistinguishable from a missing file. Narrowing it would answer 500 for a traversal and confirm something is there. The fault was never the leniency; it was handing it a name govalin had malformed itself.

**One thing the fix would otherwise have changed by accident:** with directories reaching the file server for the first time, a SPA mount would have started serving a generated listing of its own bundle. A SPA mount now answers a directory it cannot serve with the shell, matching its documented contract. Pinned by test.

Also removes the mount-root branch in `handle()`, which could never run, and records the decisions in `CONTEXT.md`.

Follow-up filed as #87: `/static` answers 404 rather than the permanent redirect the domain model documents, because a trailing-slash pattern compiles to `^/static//?$`. Not static-specific — `app.Get("/users/", …)` has it too — so it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
