### PR TITLE
Trailing-slash routes: match both spellings, redirect the static mount root

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -284,6 +284,14 @@ producing a body, since net/http discards the one an implied HEAD writes. OPTION
 equivalent: its response is not a representation of the resource, and CORS already owns that path.
 _Avoid_: 404 on a path that has a GET, an implied HEAD shadowing a registered one, GET-derived OPTIONS
 
+**Optional trailing slash**:
+A trailing slash on a registered route pattern makes the URL's trailing slash optional: both
+spellings reach the handler, which is the layer that decides which of them is canonical. A doubled
+slash is not the route — the matcher decides which URLs are the route's own rather than relying on
+the mux in front of it to have cleaned them first.
+_Avoid_: a route reachable only at the spelling it was registered with, a doubled slash matching,
+routing that assumes upstream path cleanup
+
 ## Relationships
 
 - A **Race-clean build** is a required outcome of the **Stability gate**
@@ -298,6 +306,9 @@ _Avoid_: 404 on a path that has a GET, an implied HEAD shadowing a registered on
 - Benchmark timings are advisory context for an **Allocation budget**, never the gate themselves
 - **Gate-first execution order** resolves blocking quality gates before static-route redesign
 - **Canonical static mount URL** is the trailing-slash path, with redirect from non-slash form
+- An **Optional trailing slash** is what puts a **Canonical static mount URL** within reach: both
+  spellings of the mount root route to it, so the redirect from the non-slash form has somewhere to
+  come from
 - **Permanent canonical redirect** applies to static mount root normalization
 - **Query-preserving canonicalization** keeps request query parameters unchanged during static mount redirect
 - **Framework-wide redirect integrity** applies query preservation to every framework-generated redirect

--- a/internal/routing/path-parser.go
+++ b/internal/routing/path-parser.go
@@ -59,13 +59,17 @@ func NewPathMatcherFromString(path string) (PathMatcher, error) {
 		groupRegexpParts = append(groupRegexpParts, ps.GroupedRegex)
 	}
 
+	// A trailing slash on the pattern makes the URL's trailing slash optional. It
+	// is appended after the join rather than as a segment of its own, which would
+	// put a mandatory slash in front of the optional one and leave the pattern
+	// matching only the doubled form.
+	optionalTrailingSlash := ""
 	if strings.HasSuffix(path, "/") {
-		groupRegexpParts = append(groupRegexpParts, "/?")
-		regexpParts = append(regexpParts, "/?")
+		optionalTrailingSlash = "/?"
 	}
 
-	fullGroupedRegexpString := "^/" + strings.Join(groupRegexpParts, "/") + "$"
-	fullRegexpString := "^/" + strings.Join(regexpParts, "/") + "$"
+	fullGroupedRegexpString := "^/" + strings.Join(groupRegexpParts, "/") + optionalTrailingSlash + "$"
+	fullRegexpString := "^/" + strings.Join(regexpParts, "/") + optionalTrailingSlash + "$"
 
 	return PathMatcher{
 		path:           path,

--- a/internal/routing/path-parser.go
+++ b/internal/routing/path-parser.go
@@ -11,31 +11,22 @@ import (
 )
 
 type PathMatcher struct {
-	path           string
-	segments       []pathSegment
 	pathParamNames []string
 	regexp         regexp.Regexp
-	matchRegexp    regexp.Regexp
 }
 
 func NewPathMatcherFromString(path string) (PathMatcher, error) {
 	if path == "/" {
 		return PathMatcher{
-			path:           path,
 			pathParamNames: []string{},
-			segments:       []pathSegment{rootPathSegment},
 			regexp:         *regexp.MustCompile("^/$"),
-			matchRegexp:    *regexp.MustCompile("^/$"),
 		}, nil
 	}
 
 	if path == "*" {
 		return PathMatcher{
-			path:           path,
 			pathParamNames: []string{},
-			segments:       []pathSegment{wildcardPathSegment},
 			regexp:         *regexp.MustCompile(".*?"),
-			matchRegexp:    *regexp.MustCompile(".*?"),
 		}, nil
 	}
 
@@ -52,10 +43,8 @@ func NewPathMatcherFromString(path string) (PathMatcher, error) {
 	}
 
 	groupRegexpParts := []string{}
-	regexpParts := []string{}
 
 	for _, ps := range pathSegments {
-		regexpParts = append(regexpParts, ps.Regex)
 		groupRegexpParts = append(groupRegexpParts, ps.GroupedRegex)
 	}
 
@@ -69,14 +58,10 @@ func NewPathMatcherFromString(path string) (PathMatcher, error) {
 	}
 
 	fullGroupedRegexpString := "^/" + strings.Join(groupRegexpParts, "/") + optionalTrailingSlash + "$"
-	fullRegexpString := "^/" + strings.Join(regexpParts, "/") + optionalTrailingSlash + "$"
 
 	return PathMatcher{
-		path:           path,
 		pathParamNames: pathParamNames,
-		segments:       pathSegments,
 		regexp:         *regexp.MustCompile(fullGroupedRegexpString),
-		matchRegexp:    *regexp.MustCompile(fullRegexpString),
 	}, nil
 }
 

--- a/internal/routing/path-parser.go
+++ b/internal/routing/path-parser.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 
 	"log/slog"
-
-	"github.com/pkkummermo/govalin/internal/util"
 )
 
 type PathMatcher struct {
@@ -16,7 +14,15 @@ type PathMatcher struct {
 }
 
 func NewPathMatcherFromString(path string) (PathMatcher, error) {
-	if path == "/" {
+	// A path holding nothing but slashes is the root path, spelled oddly — a
+	// route fragment and a path that both carry one produce it. Normalizing it
+	// here is what makes the matcher match the path the warning says it became,
+	// rather than the spellings it was written as.
+	if strings.Trim(path, "/ ") == "" {
+		if path != "/" {
+			slog.Warn(fmt.Sprintf("The path '%s' was converted to /", path))
+		}
+
 		return PathMatcher{
 			pathParamNames: []string{},
 			regexp:         *regexp.MustCompile("^/$"),
@@ -68,17 +74,6 @@ func NewPathMatcherFromString(path string) (PathMatcher, error) {
 func getPathSegments(path string) ([]pathSegment, error) {
 	pathSegments := []pathSegment{}
 	pathParts := strings.Split(path, "/")
-
-	// Handle "/" and multiple instances of just "///" without paths
-	if util.All(pathParts, func(part string) bool {
-		return strings.Trim(part, " ") == ""
-	}) {
-		if path != "/" {
-			slog.Warn(fmt.Sprintf("The path '%s' was converted to /", path))
-		}
-
-		return []pathSegment{rootPathSegment}, nil
-	}
 
 	for _, pathPiece := range pathParts {
 		trimmedString := strings.Trim(pathPiece, " ")

--- a/internal/routing/path-parser_test.go
+++ b/internal/routing/path-parser_test.go
@@ -42,11 +42,15 @@ func TestEndingRouteWildcardMatch(t *testing.T) {
 	assert.Equal(t, false, pathMatcher.MatchesURL("/govalintest"), "Should not match on subpartial match")
 }
 
-func TestWithEndingSlashdMatch(t *testing.T) {
+// TestOptionalTrailingSlashMatch pins both spellings of the path as the route's.
+// Which of them is canonical is the handler's to decide, not the matcher's.
+func TestOptionalTrailingSlashMatch(t *testing.T) {
 	pathMatcher, err := routing.NewPathMatcherFromString("/govalin/")
 	assert.Nil(t, err)
-	assert.Equal(t, false, pathMatcher.MatchesURL("/govalin"), "Should not match on root request")
+	assert.Equal(t, true, pathMatcher.MatchesURL("/govalin"), "Should match without the optional trailing slash")
 	assert.Equal(t, true, pathMatcher.MatchesURL("/govalin/"), "Should match on exact")
+	assert.Equal(t, false, pathMatcher.MatchesURL("/govalin//"), "Should not match a doubled slash")
+	assert.Equal(t, false, pathMatcher.MatchesURL("/govalin/sub"), "Should not match below the path")
 }
 
 func TestNestedWildcardMatch(t *testing.T) {

--- a/internal/routing/path-parser_test.go
+++ b/internal/routing/path-parser_test.go
@@ -26,6 +26,22 @@ func TestRootMatching(t *testing.T) {
 	assert.Equal(t, false, pathMatcher.MatchesURL("/govalin/"), "Should not match on trailing slash")
 }
 
+// TestAllSlashPathIsTheRootPath pins the normalization the parser has always
+// warned about but never performed: a path of nothing but slashes is the root
+// path, so the root is what it matches. It used to compile to '^///?$', matching
+// every spelling except the one it said the path had become. A route fragment
+// and a path that both end in a slash produce exactly that, so it is reachable
+// from `app.Route("/", …)` around an `app.Get("/", …)`.
+func TestAllSlashPathIsTheRootPath(t *testing.T) {
+	for _, path := range []string{"//", "///", ""} {
+		pathMatcher, err := routing.NewPathMatcherFromString(path)
+
+		assert.Nil(t, err)
+		assert.Equal(t, true, pathMatcher.MatchesURL("/"), "'%s' should match the root it was converted to", path)
+		assert.Equal(t, false, pathMatcher.MatchesURL("//"), "'%s' should not match a doubled slash", path)
+	}
+}
+
 func TestSimpleWildcardMatch(t *testing.T) {
 	pathMatcher, err := routing.NewPathMatcherFromString("*")
 	assert.Nil(t, err)

--- a/internal/routing/path-segment.go
+++ b/internal/routing/path-segment.go
@@ -22,11 +22,6 @@ var (
 		PathNames:    []string{},
 		GroupedRegex: ".+?",
 	}
-	rootPathSegment = pathSegment{
-		PathPiece:    "/",
-		PathNames:    []string{},
-		GroupedRegex: "/",
-	}
 )
 
 func newPathSegment(pathPiece string) (pathSegment, error) {

--- a/internal/routing/path-segment.go
+++ b/internal/routing/path-segment.go
@@ -8,7 +8,6 @@ import (
 
 type pathSegment struct {
 	PathPiece    string
-	Regex        string
 	GroupedRegex string
 	PathNames    []string
 }
@@ -21,13 +20,11 @@ var (
 	wildcardPathSegment = pathSegment{
 		PathPiece:    "*",
 		PathNames:    []string{},
-		Regex:        ".+?",
 		GroupedRegex: ".+?",
 	}
 	rootPathSegment = pathSegment{
 		PathPiece:    "/",
 		PathNames:    []string{},
-		Regex:        "/",
 		GroupedRegex: "/",
 	}
 )
@@ -64,7 +61,6 @@ func createNormalPathSegment(pathPiece string) pathSegment {
 	return pathSegment{
 		PathPiece:    pathPiece,
 		PathNames:    []string{},
-		Regex:        regexp.QuoteMeta(pathPiece),
 		GroupedRegex: regexp.QuoteMeta(pathPiece),
 	}
 }
@@ -73,7 +69,6 @@ func createParameterPathSegment(pathPiece string) pathSegment {
 	return pathSegment{
 		PathPiece:    pathPiece,
 		PathNames:    []string{strings.Trim(strings.Trim(pathPiece, delimiterStart), delimiterEnd)},
-		Regex:        "[^/]+?",
 		GroupedRegex: "([^/]+?)",
 	}
 }

--- a/internal/util/collection.go
+++ b/internal/util/collection.go
@@ -10,12 +10,3 @@ func ContainsSome[T comparable](collection []T, candidates ...T) bool {
 	}
 	return false
 }
-
-func All[T comparable](slice []T, pred func(T) bool) bool {
-	for _, t := range slice {
-		if !pred(t) {
-			return false
-		}
-	}
-	return true
-}

--- a/server_test.go
+++ b/server_test.go
@@ -80,6 +80,23 @@ func TestGet(t *testing.T) {
 	})
 }
 
+// TestRouteRegisteredWithATrailingSlash covers the non-static half of the same
+// bug the static mount root had: a route registered with a trailing slash was
+// reachable only at the spelling it was registered with, and answered 404 at the
+// other. Both are the route's, and what the handler makes of the difference is
+// its own business.
+func TestRouteRegisteredWithATrailingSlash(t *testing.T) {
+	app := newTestApp()
+	app.Get("/users/", func(call *govalin.Call) {
+		call.Text("users")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		assert.Equal(t, "users", client.Get("/users/"), "The registered spelling should be served")
+		assert.Equal(t, "users", client.Get("/users"), "So should the slashless one")
+	})
+}
+
 func TestPost(t *testing.T) {
 	app := newTestApp()
 	app.Post("/post", func(call *govalin.Call) {

--- a/static.go
+++ b/static.go
@@ -158,6 +158,22 @@ func (config *StaticConfig) handle(call *Call) {
 	// remove host path
 	mountPath := strings.TrimPrefix(call.URL().Path, config.hostPath)
 
+	// The mount root is a directory, so its canonical URL is the trailing-slash
+	// form like any other. Only here is the mount path the whole URL, which is
+	// why the file server cannot answer this one: it is handed the URL with the
+	// mount stripped off, leaving it nothing to redirect from. The query is
+	// carried across verbatim, since it addresses the resource, not its spelling.
+	if mountPath == "" {
+		canonicalURL := config.hostPath + "/"
+		if rawQuery := call.URL().RawQuery; rawQuery != "" {
+			canonicalURL += "?" + rawQuery
+		}
+
+		call.Redirect(canonicalURL, true)
+
+		return
+	}
+
 	hostedFileSystem := config.fsContent
 
 	if !isFS {

--- a/static_test.go
+++ b/static_test.go
@@ -390,6 +390,57 @@ func TestStaticRedirectsAFileAskedForAsADirectory(t *testing.T) {
 	})
 }
 
+// TestStaticRedirectsTheMountRootToItsCanonicalURL covers the one URL the file
+// server underneath cannot canonicalize: at the mount root the mount path is the
+// whole URL, so stripping it leaves an empty path, which net/http rewrites to
+// '/' and serves. Only the router still knows the mount path was a prefix, so
+// the redirect that keeps the slashless spelling from being a second URL for the
+// mount root is govalin's to answer.
+func TestStaticRedirectsTheMountRootToItsCanonicalURL(t *testing.T) {
+	staticRoot, _ := fs.Sub(staticTestFiles, "internal/testdata/static")
+
+	app := newTestApp()
+	app.Static("/fs", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithFS(staticRoot)
+	})
+	app.Static("/static", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithStaticPath("internal/testdata/static")
+	})
+	app.Static("/spa", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithFS(staticRoot).EnableSPAMode(true)
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		client.HTTP().CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+
+		for _, mount := range []string{"/fs", "/static", "/spa"} {
+			response := client.GetResponse(mount + "?page=2")
+			assert.Equal(
+				t,
+				http.StatusMovedPermanently,
+				response.StatusCode,
+				"The slashless mount root of %s should redirect rather than serve",
+				mount,
+			)
+
+			location, locationErr := response.Location()
+			assert.Nil(t, locationErr, "The redirect from %s should carry a location", mount)
+			assert.Equal(t, mount+"/", location.Path, "It should point at the canonical mount root of %s", mount)
+			assert.Equal(t, "page=2", location.RawQuery, "A framework redirect keeps the query it was asked with")
+
+			assert.Contains(
+				t,
+				client.Get(mount+"/"),
+				"Hello world",
+				"The canonical mount root of %s is the one that serves",
+				mount,
+			)
+		}
+	})
+}
+
 // TestStaticSPAModeResolvesDirectories covers where the unreachable directory
 // was worst: SPA mode answered the shell with a 200, so a URL that named a real
 // directory failed to resolve without anything saying so. What a SPA mount must


### PR DESCRIPTION
A static mount answered 404 at its own root without the trailing slash, and any route registered with one had the same shape — `app.Get("/users/", …)` 404'd `/users`.

**The matcher** appended the optional trailing slash as a segment of its own and then joined the segments with `/`, so `/static/` compiled to `^/static//?$` — a mandatory slash in front of the optional one, matching only the doubled spelling. It now compiles to `^/static/?$`: both spellings reach the handler and the doubled one no longer matches. The matcher decides which URLs are the route's own, rather than relying on `http.ServeMux` to have cleaned them first.

**The redirect** is the other half. Routing `/static` alone would serve content at *both* spellings, which is what **Canonical static mount URL** rules out: `serveWithFileServer` strips `hostPath` before delegating, and `net/http` rewrites the empty path that leaves to `/` and serves it. So the mount root answers a permanent redirect to the trailing-slash form from the handler — the last layer that still knows the mount path was a prefix — carrying the raw query across unchanged.

Also drops `PathMatcher.matchRegexp`: every pattern was compiled twice and only the grouped regex is ever matched against. Noticed by having to write the same trailing-slash fix into the dead twin.

Two adjacent bugs surfaced along the way and are filed rather than fixed here: #89 (a static mount inside a `Route` fragment is unreachable) and #90 (the HTTP→HTTPS plugin drops the query string).

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)
