### PR TITLE
docs: adopt the code-comment rules from mypharmacy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,49 @@
+# Agent Guidelines
+
+## Code comments
+
+Govalin is a public library, so an **exported identifier carries a doc comment** — that is the API
+reference, and godoc is where users read it. State the contract the caller gets, in a sentence or
+two.
+
+Everything else defaults to **no comment**: inside a function, names and structure should carry the
+meaning.
+
+Write one only to record a non-obvious *why* a future reader cannot recover from the code itself: a
+spec requirement, an external-bug workaround, or a deliberate choice someone would otherwise "fix".
+One line.
+
+Never:
+
+- explain why a change was made or what alternative was rejected — that is commit/PR/ADR material
+  (if a comment would fit in a PR description or an ADR's Considered Options, it does not belong in
+  the source);
+- restate what the code does;
+- write multi-line narrative or reasoning blocks.
+
+### Examples
+
+```go
+// BAD — restates the code:
+// Reserve port and buffer incoming connections
+listener, err := net.Listen("tcp", addr)
+
+// BAD — a reasoning block re-arguing a decision, with the rejected alternative inline:
+// Flush the buffered status on every non-bypass exit path so a handler (or a
+// short-circuiting before handler) that sets a status but writes no body still sends
+// that status instead of an implicit 200 OK. The bypass check is evaluated when the
+// defer runs, not when it is registered, because HTTPServe sets bypassLifecycle inside
+// the handler which runs after this point; a snapshot here would wrongly flush over a
+// raw response. Registered after the access-log defer so LIFO ordering flushes before
+// the log records the status. ...
+
+// GOOD — one line, the non-obvious why the code can't tell you:
+// Read when the defer fires, not when it is registered: HTTPServe sets it later (ADR 0002).
+
+// GOOD — cites the decision instead of restating it:
+// The call ID is deliberately logged as sent — see ADR 0006.
+```
+
+When in doubt, delete the comment: if the next reader could recover the fact from the code, it is
+noise. What the code does belongs in the code, what a decision cost belongs in
+[docs/adr/](docs/adr/), and the vocabulary belongs in [CONTEXT.md](CONTEXT.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,9 @@
 
 Govalin is a public library, so an **exported identifier carries a doc comment** — that is the API
 reference, and godoc is where users read it. State the contract the caller gets, in a sentence or
-two.
+two. A doc comment may run longer when the contract does — what a caller cannot discover by reading
+the signature, such as which failures `Stream` returns and which it swallows. Length in a doc
+comment is a question about the contract; length inside a function body never is.
 
 Everything else defaults to **no comment**: inside a function, names and structure should carry the
 meaning.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/call.go
+++ b/call.go
@@ -62,9 +62,7 @@ func newCallFromRequest(w http.ResponseWriter, req *http.Request, config *Config
 		uniqueID = govalinIDHeader[0]
 	}
 
-	// Everything writes through the recording writer, including handlers that
-	// take the raw writer, so govalin can tell whether the response has been
-	// committed no matter who committed it.
+	// Even Raw.W goes through the recording writer, so govalin sees a commit whoever made it.
 	recordingWriter := newResponseWriter(w)
 	var rawWriter http.ResponseWriter = recordingWriter
 
@@ -95,7 +93,6 @@ func newCallFromRequest(w http.ResponseWriter, req *http.Request, config *Config
 func initiateSessionFromCall(call *Call) {
 	sessionCookie, getSessionErr := call.Cookie(sessionCookieName)
 
-	// Create the session if it doesn't exist
 	if errors.Is(getSessionErr, http.ErrNoCookie) {
 		addNewSessionErr := addNewSessionToCall(call)
 		if addNewSessionErr != nil {
@@ -105,7 +102,6 @@ func initiateSessionFromCall(call *Call) {
 	}
 
 	session, getSessionErr := call.config.server.sessionStore.GetSession(sessionCookie.Value, 0)
-	// The session might be expired, so we need to create a new one
 	if getSessionErr != nil {
 		slog.Debug("Failed to get session from session store, adding new session", "err", getSessionErr)
 		addNewSessionErr := addNewSessionToCall(call)
@@ -138,12 +134,7 @@ func addNewSessionToCall(call *Call) error {
 		Value:   sessionID,
 		Expires: time.Now().Add(call.config.server.sessionExpireTime),
 		Path:    "/",
-		// Harden the session cookie. HttpOnly keeps it out of reach of
-		// JavaScript and SameSite=Lax mitigates CSRF while allowing top-level
-		// navigations. Secure is enabled whenever the request is served over
-		// HTTPS (directly or behind a TLS-terminating proxy) so the cookie is
-		// restricted to secure transport in production without breaking
-		// plain-HTTP local development.
+		// Secure follows the request, so production gets it without breaking plain-HTTP local dev.
 		HttpOnly: true,
 		Secure:   call.isSecure(),
 		SameSite: http.SameSiteLaxMode,
@@ -184,9 +175,7 @@ func (call *Call) limitBody(maxSize int64) error {
 		return errBodyTooLarge
 	}
 
-	// The unwrapped writer: MaxBytesReader type-asserts it against an unexported
-	// net/http interface to close the connection on an over-long body, and an
-	// assertion does not see through the recording wrapper.
+	// Unwrapped: MaxBytesReader type-asserts net/http's own writer, which the wrapper hides.
 	call.req.Body = http.MaxBytesReader(call.w.ResponseWriter, call.req.Body, maxSize)
 
 	return nil
@@ -371,8 +360,7 @@ func (call *Call) sendStatusOrDefault() {
 		call.status = http.StatusOK
 	}
 
-	// A 304 sends no representation, so the headers describing one are dropped,
-	// whether the handler returned early or wrote a body about to be refused.
+	// A 304 sends no representation, so the headers describing one are dropped.
 	if call.status == http.StatusNotModified {
 		call.w.Header().Del(headers.ContentType)
 		call.w.Header().Del(headers.ContentLength)
@@ -801,8 +789,6 @@ func (call *Call) Error(err error) {
 
 	var validationErr *validation.Error
 	if errors.As(err, &validationErr) {
-		// Use the status the error carries so non-400 validation errors surface
-		// their real status.
 		call.Status(validationErr.Status())
 		call.JSON(validationErr.ErrorResponse)
 		return
@@ -849,7 +835,6 @@ func (call *Call) ValidatedFormParam(key string) *StringValidator {
 		value: value,
 		rules: make([]func(string, string) error, 0),
 	}
-	// If there's an error getting the form param, add it as a rule
 	if err != nil {
 		validator.rules = append(validator.rules, func(_, _ string) error { return err })
 	}
@@ -887,7 +872,6 @@ func (call *Call) ValidatedFormParamAsInt(key string) *IntValidator {
 		value: value,
 		rules: make([]func(int, string) error, 0),
 	}
-	// If there's an error getting the form param, add it as a rule
 	if err != nil {
 		validator.rules = append(validator.rules, func(_ int, _ string) error { return err })
 	}

--- a/govalintest/govalintest.go
+++ b/govalintest/govalintest.go
@@ -94,10 +94,7 @@ func TestWithOptions(t *testing.T, app *govalin.App, opts Options, fn func(clien
 	}()
 
 	t.Cleanup(func() {
-		// Hand the connections back before shutting down. A keep-alive connection
-		// the server has accepted but not yet read a request from does not count as
-		// idle, so Shutdown would wait for it until the read header timeout and
-		// then fail on its own deadline.
+		// An accepted connection with no request yet is not idle, so Shutdown would wait it out.
 		httpClient.CloseIdleConnections()
 
 		if err := app.Shutdown(); err != nil {

--- a/internal/routing/path-parser.go
+++ b/internal/routing/path-parser.go
@@ -14,10 +14,8 @@ type PathMatcher struct {
 }
 
 func NewPathMatcherFromString(path string) (PathMatcher, error) {
-	// A path holding nothing but slashes is the root path, spelled oddly — a
-	// route fragment and a path that both carry one produce it. Normalizing it
-	// here is what makes the matcher match the path the warning says it became,
-	// rather than the spellings it was written as.
+	// A path of nothing but slashes is the root spelled oddly, and a route fragment
+	// joined to a path produces it. The matcher has to match what the warning says it became.
 	if strings.Trim(path, "/ ") == "" {
 		if path != "/" {
 			slog.Warn(fmt.Sprintf("The path '%s' was converted to /", path))
@@ -53,10 +51,8 @@ func NewPathMatcherFromString(path string) (PathMatcher, error) {
 		groupRegexpParts = append(groupRegexpParts, ps.GroupedRegex)
 	}
 
-	// A trailing slash on the pattern makes the URL's trailing slash optional. It
-	// is appended after the join rather than as a segment of its own, which would
-	// put a mandatory slash in front of the optional one and leave the pattern
-	// matching only the doubled form.
+	// Appended after the join, not as a segment: a segment carries a mandatory slash in
+	// front of the optional one, leaving the pattern matching only the doubled form.
 	optionalTrailingSlash := ""
 	if strings.HasSuffix(path, "/") {
 		optionalTrailingSlash = "/?"

--- a/internal/routing/path-parser.go
+++ b/internal/routing/path-parser.go
@@ -43,7 +43,6 @@ func NewPathMatcherFromString(path string) (PathMatcher, error) {
 	}
 
 	var pathParamNames = []string{}
-	// Extract path param names
 	for _, ps := range pathSegments {
 		pathParamNames = append(pathParamNames, ps.PathNames...)
 	}

--- a/internal/routing/path-segment.go
+++ b/internal/routing/path-segment.go
@@ -29,22 +29,18 @@ func newPathSegment(pathPiece string) (pathSegment, error) {
 	delimiterEndCount := strings.Count(pathPiece, delimiterEnd)
 	totalDelimiters := delimiterStartCount + delimiterEndCount
 
-	// Error in number of delimiters
 	if delimiterStartCount != delimiterEndCount {
 		return pathSegment{}, fmt.Errorf("number of '%d' and '%d' is not the same", delimiterStartCount, delimiterEndCount)
 	}
 
-	// Wildcard
 	if pathPiece == wildcard {
 		return wildcardPathSegment, nil
 	}
 
-	// No matcher
 	if totalDelimiters == 0 {
 		return createNormalPathSegment(pathPiece), nil
 	}
 
-	// Simple matcher
 	if totalDelimiters == 2 && pathPiece[0:1] == delimiterStart && pathPiece[len(pathPiece)-1:] == delimiterEnd {
 		return createParameterPathSegment(pathPiece), nil
 	}

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -11,7 +11,6 @@ import (
 
 // GetUnmarshalError returns a validation Error based on given UnmarshalTypeError.
 func GetUnmarshalError(err *json.UnmarshalTypeError) *Error {
-	// If the type is nested we still only want the type
 	expectedTypeChunk := strings.Split(err.Type.String(), ".")
 	expectedType := expectedTypeChunk[len(expectedTypeChunk)-1]
 

--- a/logsafe.go
+++ b/logsafe.go
@@ -6,21 +6,15 @@ import (
 )
 
 const (
-	// maxLoggedValueLength bounds a request-derived value in the access log. Long
-	// enough for a realistic user agent or path, short enough that a request
-	// cannot decide how much a log line costs.
+	// maxLoggedValueLength keeps a request from deciding how much a log line costs.
 	maxLoggedValueLength = 256
 
-	// truncationMarker is appended to a value that was cut short, so a truncated
-	// value is never mistaken for the value the client actually sent.
+	// truncationMarker marks a cut value so it is not read as what the client sent.
 	truncationMarker = "…"
 )
 
-// logSafeValue bounds a request-derived value and drops control characters,
-// marking truncation so a cut value is not read as what the client sent. The
-// bound is the point — nothing else caps a client-chosen path or user agent.
-// Scrubbing is defence in depth: slog's own handlers escape control characters,
-// but a percent-encoded path does decode into raw ones.
+// logSafeValue bounds a request-derived value and drops control characters. The bound is
+// the point — nothing else caps a client-chosen path or user agent.
 func logSafeValue(value string) string {
 	var builder strings.Builder
 

--- a/plugins/routing/httpToHttpsRedirect.go
+++ b/plugins/routing/httpToHttpsRedirect.go
@@ -30,15 +30,13 @@ func (config *HTTPToHTTPSConfig) Apply(app *govalin.App) {
 		callHost := call.Host()
 		isLocalhost := strings.HasPrefix(callHost, "localhost")
 
-		// Don't redirect localhost unless configured
 		if !config.redirectLocalhost && isLocalhost {
 			return true
 		}
 
-		// Redirect if scheme is http or forwarded scheme is http
 		xForwardedProto := call.Header(headers.XForwardedProto)
 		if xForwardedProto == "http" || (xForwardedProto == "" && call.Raw.Req.TLS == nil) {
-			// More often than not we do not want to redirect to HTTPS on localhost, at least not permanently
+			// Temporary on localhost: a permanent redirect would stick in the browser's cache.
 			if isLocalhost {
 				call.Redirect("https://"+callHost+call.URL().Path, false)
 			} else {

--- a/responsewriter.go
+++ b/responsewriter.go
@@ -28,10 +28,7 @@ func newResponseWriter(writer http.ResponseWriter) *responseWriter {
 // still forwarded, so net/http keeps reporting a genuine double write; the
 // framework's own status flush is guarded by the committed flag instead.
 func (writer *responseWriter) WriteHeader(status int) {
-	// 1xx responses are informational: net/http may send several and the real
-	// status still follows, so they do not commit the response. 101 is the
-	// exception net/http itself makes — nothing follows a protocol switch, so it
-	// is a final status.
+	// 1xx is informational and the real status still follows; 101 is net/http's own exception.
 	if !writer.committed && (status >= http.StatusOK || status == http.StatusSwitchingProtocols) {
 		writer.status = status
 		writer.committed = true

--- a/server.go
+++ b/server.go
@@ -388,10 +388,8 @@ func (server *App) matchHandlers(call *Call) {
 		return
 	}
 
-	// HEAD is GET without a body (RFC 9110 §9.3.2), so a path govalin has a GET
-	// for answers a HEAD with it — net/http drops the body the handler writes. A
-	// second pass rather than a fallback inside the lookup, so that a handler
-	// registered for HEAD wins wherever it sits in the route table.
+	// HEAD is GET without a body (RFC 9110 §9.3.2), and net/http drops the body a GET handler
+	// writes. A second pass, so a registered HEAD wins wherever it sits in the route table.
 	if call.Method() == http.MethodHead {
 		server.callHandlerByMethod(call, http.MethodGet)
 	}

--- a/server.go
+++ b/server.go
@@ -258,21 +258,16 @@ func (server *App) Start(port ...uint16) error {
 		server.port = server.config.server.port
 	}
 
-	// Reserve port and buffer incoming connections
 	listener, listenerErr := net.Listen("tcp", fmt.Sprintf(":%d", server.port))
 	if listenerErr != nil {
 		return listenerErr
 	}
 
-	// Read the port back from the listener so the bound port is authoritative.
-	// When the configured port is 0 the OS assigns a free port, which is only
-	// reflected in listener.Addr(); without this, server.port would stay 0 and
-	// Port() would report a port the server is not listening on.
+	// A configured port of 0 is assigned by the OS, and only listener.Addr() knows what it got.
 	if tcpAddr, ok := listener.Addr().(*net.TCPAddr); ok {
 		server.port = uint16(tcpAddr.Port)
 	}
 
-	// Initialize all plugins
 	for _, plugin := range server.config.server.plugins {
 		slog.Debug(fmt.Sprintf("Plugins: Running Apply for '%s'", plugin.Name()))
 		plugin.Apply(server)
@@ -379,7 +374,6 @@ func (server *App) matchBeforeHandlers(call *Call) bool {
 		if pathHandler.Before != nil && pathHandler.PathMatcher.MatchesURL(call.URL().Path) {
 			call.pathParams = pathHandler.PathMatcher.PathParams(call.URL().Path)
 
-			// Return false means short circuit, return false
 			if !pathHandler.Before(call) {
 				return false
 			}
@@ -446,60 +440,44 @@ func (server *App) rootHandlerFunc(w http.ResponseWriter, req *http.Request) {
 		map[string]string{},
 	)
 
-	// Log the access log once, on every exit path, so requests that take over
-	// the lifecycle (e.g. HTTPServe) or short-circuit in a before handler are
-	// logged consistently and only when access logging is enabled.
+	// Deferred so a bypassed or short-circuited request is logged like any other.
 	if server.config.server.accessLogEnabled {
 		defer func() {
 			server.logAccessLog(&call, float64(time.Since(incomingRequestTime))/float64(time.Millisecond))
 		}()
 	}
 
-	// Flush the buffered status on every non-bypass exit path so a handler (or a
-	// short-circuiting before handler) that sets a status but writes no body
-	// still sends that status instead of an implicit 200 OK. The bypass check is
-	// evaluated when the defer runs, not when it is registered, because
-	// HTTPServe sets bypassLifecycle inside the handler which runs after this
-	// point; a snapshot here would wrongly flush over a raw response. Registered
-	// after the access-log defer so LIFO ordering flushes before the log records
-	// the status. sendStatusOrDefault is idempotent, so an already-written
-	// response is left untouched.
+	// Registered after the access-log defer so LIFO flushes the status before it is logged.
+	// bypassLifecycle is read when the defer runs; HTTPServe sets it later, inside the handler.
 	defer func() {
 		if !call.bypassLifecycle {
 			call.sendStatusOrDefault()
 		}
 	}()
 
-	// Look for before handlers
 	if !server.matchBeforeHandlers(&call) || call.bypassLifecycle {
 		return
 	}
 
-	// Look for endpoint handler
 	server.matchHandlers(&call)
 	if call.bypassLifecycle {
 		return
 	}
 
-	// Look for After handlers
 	server.matchAfterHandlers(&call)
 	if call.bypassLifecycle {
 		return
 	}
 
-	// No status set and nothing written, meaning no handlers have handled the
-	// request properly, ie 404 / not found. A handler that wrote the response
-	// itself without setting a status has handled it; appending a 404 body to
-	// what it sent would corrupt the response.
+	// A handler that wrote without setting a status has handled it; a 404 body would corrupt it.
 	if call.Status() == 0 && !call.committed() {
 		server.notFoundHandler(&call)
 	}
 }
 
 func (server *App) logAccessLog(call *Call, durationInMS float64) {
-	// Path and user agent come straight off the wire and are capped by nothing
-	// else, so bound them rather than let a request decide how large a log line
-	// is. The call ID is deliberately logged as sent — see ADR 0006.
+	// The call ID is deliberately logged as sent, unlike the other request-controlled
+	// values here — see ADR 0006.
 	slog.Info(
 		"incoming request",
 		slog.String("id", call.ID()),

--- a/static.go
+++ b/static.go
@@ -62,13 +62,9 @@ func failStatic(call *Call, err error, message string) {
 	}
 }
 
-// validatorFor derives the validator for a static file: from when the file
-// changed if the file system knows, from what it contains if it does not. An
-// embedded file system reports no modification time, so content is all that is
-// left to identify a file by, and the hash is paid once for the mount's life.
-//
-// Both forms are strong tags, because net/http requires a strong match for
-// If-Range and a weak one would quietly cost every resumed download its ranges.
+// validatorFor derives the validator for a static file: from when the file changed if the
+// file system knows, from what it contains if it does not, as an embedded one does not.
+// Both forms are strong tags — net/http needs a strong match to honour If-Range.
 func (config *StaticConfig) validatorFor(hostedFileSystem fs.FS, name string, fileInfo fs.FileInfo) string {
 	if !fileInfo.ModTime().IsZero() {
 		return fmt.Sprintf("%x-%x", fileInfo.ModTime().UnixNano(), fileInfo.Size())
@@ -123,15 +119,12 @@ func (config *StaticConfig) serveFile(call *Call, hostedFileSystem fs.FS, name s
 		return statErr
 	}
 
-	// Both sinks below revalidate the same way, so the check happens here rather
-	// than in http.ServeContent, which only the seekable one reaches.
+	// Both sinks revalidate the same way; http.ServeContent covers only the seekable one.
 	if etag := config.validatorFor(hostedFileSystem, name, fileInfo); etag != "" && call.NotModified(etag) {
 		return nil
 	}
 
-	// Range support needs to seek. Every file system govalin mounts (an os.Root
-	// and the embedded FS) gives seekable files; a custom one that does not still
-	// gets served, just without ranges.
+	// Only a seekable file can serve ranges; os.Root and embed give one, a custom fs.FS may not.
 	seekableFile, isSeekable := file.(io.ReadSeeker)
 	if !isSeekable {
 		return call.Stream(mime.TypeByExtension(path.Ext(name)), file)
@@ -155,7 +148,6 @@ func (config *StaticConfig) serveWithFileServer(call *Call, hostedFileSystem fs.
 func (config *StaticConfig) handle(call *Call) {
 	isFS := config.fsContent != nil
 
-	// remove host path
 	mountPath := strings.TrimPrefix(call.URL().Path, config.hostPath)
 
 	// The mount root is a directory, so its canonical URL is the trailing-slash
@@ -177,9 +169,7 @@ func (config *StaticConfig) handle(call *Call) {
 	hostedFileSystem := config.fsContent
 
 	if !isFS {
-		// Every read below the mount goes through the root, so a traversal
-		// segment or a symlink pointing outside the static directory is refused
-		// by the OS instead of by string comparison on a cleaned path.
+		// os.Root has the OS refuse an escaping symlink or traversal, not a path compare (ADR 0006).
 		root, rootErr := os.OpenRoot(config.staticPath)
 		if rootErr != nil {
 			slog.Error(fmt.Sprintf(`Failed to open the configured static file folder.
@@ -194,19 +184,15 @@ Are you sure it exists and is readable on the given path: '%s'`, config.staticPa
 		hostedFileSystem = root.FS()
 	}
 
-	// A trailing slash is the URL claiming the name addresses a directory. io/fs
-	// refuses a name carrying one, so it is kept here as a claim to answer
-	// against what the name turns out to hold, and dropped from the name itself.
+	// io/fs refuses a name carrying a trailing slash, so the URL's claim is kept apart from it.
 	namedAsDirectory := strings.HasSuffix(mountPath, "/")
 
-	// An fs.FS addresses entries relative to its root, and names the root
-	// directory itself "." rather than the empty string.
+	// An fs.FS names its own root "." rather than the empty string.
 	name := strings.TrimRight(strings.TrimPrefix(mountPath, "/"), "/")
 	if name == "" {
 		name = "."
 	}
 
-	// check whether a file exists at the given path
 	fileInfo, statErr := fs.Stat(hostedFileSystem, name)
 
 	var pathErr *fs.PathError
@@ -215,8 +201,7 @@ Are you sure it exists and is readable on the given path: '%s'`, config.staticPa
 	// escaping symlink must not answer differently from a name that isn't there.
 	isNotFoundError := errors.Is(statErr, fs.ErrNotExist) || errors.As(statErr, &pathErr)
 
-	// A name that resolves to nothing is a client-side route on a SPA mount, so
-	// the shell answers it.
+	// A name that resolves to nothing is a client-side route on a SPA mount.
 	if config.spaMode && isNotFoundError {
 		config.serveIndex(call, hostedFileSystem)
 		return
@@ -224,16 +209,12 @@ Are you sure it exists and is readable on the given path: '%s'`, config.staticPa
 
 	switch {
 	case isNotFoundError:
-		// Answer directly instead of handing an unresolvable name to the file
-		// server. A name that escapes the root is not a missing file to it, so it
-		// would answer 500 and thereby confirm that something is there.
+		// The file server answers an escaping name with 500, which confirms something is there.
 		call.Status(http.StatusNotFound)
 		call.Text("404 page not found")
 
 		return
 	case statErr != nil:
-		// if we got an error (that wasn't that the file doesn't exist) stating the
-		// file, return a 500 internal server error and stop
 		call.Status(http.StatusInternalServerError)
 		call.Error(statErr)
 		return
@@ -245,10 +226,7 @@ Are you sure it exists and is readable on the given path: '%s'`, config.staticPa
 
 		return
 	case fileInfo.IsDir():
-		// A directory holding an index.html is serving a file, and goes through
-		// Call like any other so that it carries a validator — the mount root is
-		// the most requested URL a static site has. Without one, the generated
-		// listing is the file server's, having no validator to derive.
+		// A directory with an index.html is serving a file, so it goes through Call for a validator.
 		indexName := path.Join(name, indexFileName)
 		if _, indexErr := fs.Stat(hostedFileSystem, indexName); indexErr != nil {
 			// Except on a SPA mount, which answers everything that is not a file
@@ -315,8 +293,7 @@ func (server *App) Static(path string, staticHandlerFunc StaticHandlerFunc) *App
 	normalizedPath := strings.TrimRight(path, "/*")
 	wildcardPath := normalizedPath + "/*"
 
-	// The config is rebuilt per request, so hashed validators live out here with
-	// the mount they describe — which is what makes the file name a sufficient key.
+	// Outlives the per-request config, and is scoped to one mount, so the file name is key enough.
 	validators := &sync.Map{}
 
 	staticGetHandler := func(call *Call) {

--- a/static.go
+++ b/static.go
@@ -150,11 +150,8 @@ func (config *StaticConfig) handle(call *Call) {
 
 	mountPath := strings.TrimPrefix(call.URL().Path, config.hostPath)
 
-	// The mount root is a directory, so its canonical URL is the trailing-slash
-	// form like any other. Only here is the mount path the whole URL, which is
-	// why the file server cannot answer this one: it is handed the URL with the
-	// mount stripped off, leaving it nothing to redirect from. The query is
-	// carried across verbatim, since it addresses the resource, not its spelling.
+	// The file server is handed the URL with the mount stripped off, so this is the one
+	// trailing-slash redirect it cannot make. The query addresses the resource, not its spelling.
 	if mountPath == "" {
 		canonicalURL := config.hostPath + "/"
 		if rawQuery := call.URL().RawQuery; rawQuery != "" {
@@ -197,8 +194,7 @@ Are you sure it exists and is readable on the given path: '%s'`, config.staticPa
 
 	var pathErr *fs.PathError
 
-	// A name the file system refuses is a missing file here: a '..' segment or an
-	// escaping symlink must not answer differently from a name that isn't there.
+	// A '..' segment or an escaping symlink must not answer differently from a missing file.
 	isNotFoundError := errors.Is(statErr, fs.ErrNotExist) || errors.As(statErr, &pathErr)
 
 	// A name that resolves to nothing is a client-side route on a SPA mount.
@@ -219,9 +215,8 @@ Are you sure it exists and is readable on the given path: '%s'`, config.staticPa
 		call.Error(statErr)
 		return
 	case fileInfo.IsDir() != namedAsDirectory:
-		// The URL's claim and the file system disagree, in either direction: the
-		// file server redirects to the spelling that addresses what is there, so
-		// that neither is served at both.
+		// The URL and the file system disagree, so the file server redirects to the
+		// spelling that addresses what is there, and neither is served at both.
 		config.serveWithFileServer(call, hostedFileSystem)
 
 		return
@@ -229,8 +224,7 @@ Are you sure it exists and is readable on the given path: '%s'`, config.staticPa
 		// A directory with an index.html is serving a file, so it goes through Call for a validator.
 		indexName := path.Join(name, indexFileName)
 		if _, indexErr := fs.Stat(hostedFileSystem, indexName); indexErr != nil {
-			// Except on a SPA mount, which answers everything that is not a file
-			// with the shell, so its bundle is nobody's to enumerate.
+			// Except on a SPA mount, whose bundle is nobody's to enumerate.
 			if config.spaMode {
 				config.serveIndex(call, hostedFileSystem)
 			} else {

--- a/stream.go
+++ b/stream.go
@@ -31,8 +31,7 @@ func (call *Call) Stream(contentType string, reader io.Reader) error {
 
 	call.sendStatusOrDefault()
 
-	// io.Copy reports a read and a write failure the same way, and the two call
-	// for opposite answers, so the source keeps its own error.
+	// io.Copy cannot say which side failed, and the two sides call for opposite answers.
 	source := &sourceReader{reader: reader}
 
 	if _, err := io.Copy(call.w, source); err != nil {
@@ -75,8 +74,7 @@ func (source *sourceReader) Read(buffer []byte) (int, error) {
 func (call *Call) ServeContent(name string, modTime time.Time, content io.ReadSeeker) {
 	http.ServeContent(call.w, call.req, name, modTime, content)
 
-	// Keep the buffered status in step with what went out, so after handlers see
-	// the real status.
+	// After handlers read the buffered status, so it has to match what went out.
 	call.status = call.w.status
 }
 

--- a/validation.go
+++ b/validation.go
@@ -182,7 +182,6 @@ func (v *IntValidator) Custom(fn func(int) bool, message string) *IntValidator {
 
 // Get validates the integer and returns it if valid.
 func (v *IntValidator) Get() (int, error) {
-	// First try to convert string to int
 	intVal, err := strconv.Atoi(v.value)
 	if err != nil {
 		return 0, validation.NewError(validation.NewErrorResponse(
@@ -191,7 +190,6 @@ func (v *IntValidator) Get() (int, error) {
 		))
 	}
 
-	// Then apply validation rules
 	for _, rule := range v.rules {
 		if errRule := rule(intVal, v.key); errRule != nil {
 			return 0, errRule
@@ -223,12 +221,10 @@ func (v *BodyValidator) Custom(validatorFn func(interface{}) bool, message strin
 
 // Get validates the body and returns error if invalid.
 func (v *BodyValidator) Get() error {
-	// First unmarshal the body
 	if err := v.call.BodyAs(v.target); err != nil {
 		return err
 	}
 
-	// Then apply validation rules
 	for _, rule := range v.rules {
 		if err := rule(v.target); err != nil {
 			return err

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -8,8 +8,6 @@ import (
 	"github.com/pkkummermo/govalin/internal/validation"
 )
 
-// Validation types exposed without problematic generic type aliases
-
 // NewStringValidator provides type-safe string validation.
 func NewStringValidator() *validation.Validator[string] {
 	return validation.Validate[string]()

--- a/ws.go
+++ b/ws.go
@@ -179,12 +179,8 @@ func (server *App) Ws(path string, handlerFunc WsHandlerFunc) *App {
 	server.addMethod(http.MethodGet, server.currentFragment+path, func(call *Call) {
 		call.Status(http.StatusSwitchingProtocols)
 
-		// A websocket upgrade hijacks the connection (or, on failure, lets the
-		// upgrader write its own HTTP error), so the handler owns response
-		// finalization from here on — just like HTTPServe. Bypass the govalin
-		// lifecycle to suppress the end-of-request status flush, which would
-		// otherwise attempt a WriteHeader on the hijacked connection. See
-		// CONTEXT.md "Lifecycle bypass".
+		// The upgrader owns the response from here: it hijacks the connection, or writes its
+		// own HTTP error. See CONTEXT.md, "Lifecycle bypass".
 		call.bypassLifecycle = true
 
 		wsCall, upgradeErr := wsConfig.OnUpgrade(call)


### PR DESCRIPTION
Govalin had no agent guidelines file. This adds `AGENTS.md` with mypharmacy's `## Code comments` section, plus a `CLAUDE.md` that imports it — the same two-file setup mypharmacy uses.

One deliberate deviation: govalin is a public library, so "default to no comment" cannot apply to exported identifiers, since godoc *is* the API reference. The section carves that out first and applies the mypharmacy rule to everything else.

Examples are real govalin code rather than mypharmacy's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)