### PR TITLE
Freshness headers: Cache-Control for handlers and static mounts

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -277,6 +277,22 @@ to. The 304 is buffered the moment the match is found, so a handler that produce
 sends a correct empty 304 — it has wasted only its own work.
 _Avoid_: correctness that depends on the caller reading a return value, a body inside a 304
 
+**Freshness**:
+How long a client may reuse a response it has stored before it has to ask again, declared by the
+server as a lifetime and counted down by the client. The other half of caching from **Cache
+validation**: a **Validator** makes a revalidation cheap, only freshness makes it unnecessary.
+Binding, not advisory — a lifetime cannot be withdrawn from a cache the server never sees, which is
+why a static mount declares none until it is asked to.
+_Avoid_: "caching" as one undivided feature, freshness as a stronger validator, a framework-chosen
+default lifetime
+
+**Cache scope**:
+Which caches may store a response — any of them, only the client that asked (`private`), or none at
+all (`no-store`). A separate question from **Freshness**, which says only how long: a response behind
+a login is a scope decision and a lifetime decision, answered deliberately rather than inferred from
+each other.
+_Avoid_: `public` as a synonym for cacheable, a scope read off how long something stays fresh
+
 **Implied HEAD**:
 A HEAD answered by the route's GET handler, because HEAD is GET without a body. A handler registered
 for HEAD replaces it wherever it sits in the route table — that is how a route buys the right to skip
@@ -350,6 +366,12 @@ routing that assumes upstream path cleanup
 - A **Revalidation short-circuit** buffers 304 like any other **Buffered status**, so **Status flush** and **Committed response** govern it unchanged
 - A 304 carries no representation, so the **Status flush** drops the headers that describe one
 - A **Strong validator** is what keeps **Ranged content** resumable across a revalidation
+- **Freshness** and **Cache validation** are the two halves of one feature, not alternatives: the
+  first removes the request, the second answers it cheaply when it comes
+- A **Derived validator** is on by default and **Freshness** never is, and the asymmetry is the point:
+  an advisory validator costs a client nothing to ignore, a lifetime binds it until the clock runs out
+- A 304 carries the **Freshness** of the response it stands in for, so a **Revalidation
+  short-circuit** renews the stored copy rather than leaving the client asking on every reuse
 - An **Implied HEAD** is what lets a static mount answer a cache probe: the **Derived validator** and
   the length are already on the response its GET handler produces
 - An **Implied HEAD** is logged as the HEAD it is; that a GET handler answered it is routing, not
@@ -366,3 +388,4 @@ routing that assumes upstream path cleanup
 - CI currently runs default tests but does not run race tests; resolved: race-clean will be enforced in CI as a mandatory gate.
 - Existing HTTP->HTTPS plugin redirect currently uses only URL path and drops query parameters; resolved: query-preserving behavior applies framework-wide and this behavior must be aligned.
 - "ETag support" was used to mean both cache validation and optimistic concurrency control; resolved: this work is cache validation only, and a precondition on an unsafe method is a separate feature that would need its own name.
+- "caching" was used to mean both freshness and cache validation; resolved: they are the two halves of caching, and a request that never happens is the one freshness is for.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -372,6 +372,11 @@ routing that assumes upstream path cleanup
   an advisory validator costs a client nothing to ignore, a lifetime binds it until the clock runs out
 - A 304 carries the **Freshness** of the response it stands in for, so a **Revalidation
   short-circuit** renews the stored copy rather than leaving the client asking on every reuse
+- A **SPA fallback** is the one response govalin gives a **Freshness** of its own without being
+  asked, and it is the absence of one: the shell names the fingerprinted assets, so **Freshness** on
+  a SPA mount is for what the shell points at and never for the shell
+- A shell that is never fresh is affordable because its **Derived validator** is: never stale costs a
+  304, not a bundle
 - An **Implied HEAD** is what lets a static mount answer a cache probe: the **Derived validator** and
   the length are already on the response its GET handler produces
 - An **Implied HEAD** is logged as the HEAD it is; that a GET handler answered it is routing, not

--- a/README.md
+++ b/README.md
@@ -117,7 +117,8 @@ the client serves the response from its own cache and never asks.
 ```go
 call.CacheFor(10 * time.Minute)        // Cache-Control: max-age=600
 call.CachePrivateFor(1 * time.Minute)  // ...and only in the browser that asked for it
-call.NoStore()                         // ...and nowhere at all
+call.NoCache()                         // keep it, but check with me before every reuse
+call.NoStore()                         // don't keep it at all
 ```
 
 - `CacheFor` says how long, and nothing about who — a shared cache decides that for itself.
@@ -142,9 +143,22 @@ app.Static("/assets", func(_ *govalin.Call, config *govalin.StaticConfig) {
 })
 ```
 
-That is what turns an embedded bundle from one round trip per asset per page load into none. It
-covers every file the mount serves, `index.html` included, so a shell that has to reach clients on
-the next deploy wants a short one.
+That is what turns an embedded bundle from one round trip per asset per page load into none.
+
+On a mount in SPA mode the shell is the exception, and govalin makes it for you: `index.html` is
+served `no-cache` whatever the mount declares, at the mount root, at its own URL and at every
+client-side route it answers. The shell names the hashed bundles, so a client holding an old copy
+asks for assets the deploy has already replaced — and being served at every URL the app routes, a
+stale one is the whole app. Checking is cheap: the derived validator answers it with a 304.
+
+That is the split an asset pipeline is built around. Give the fingerprinted files a long lifetime,
+and let the one file that names them stay honest:
+
+```go
+app.Static("/", func(_ *govalin.Call, config *govalin.StaticConfig) {
+	config.WithFS(bundle).EnableSPAMode(true).CacheFor(24 * time.Hour)
+})
+```
 
 ## Testing your app
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ is logged at debug level.
 
 ## Caching
 
+### Validation
+
 `NotModified` answers a client that already has the resource, so a revalidation costs headers
 instead of a body:
 
@@ -106,6 +108,43 @@ Static mounts do this for themselves, with no configuration. A file served from 
 when it changed and how big it is; an embedded file, which has no modification time to offer, is
 validated by a hash of its content, computed once per file. Both are strong tags, so resumable
 downloads stay resumable.
+
+### Freshness
+
+A validator makes a revalidation cheap. What makes it unnecessary is a lifetime: until it runs out,
+the client serves the response from its own cache and never asks.
+
+```go
+call.CacheFor(10 * time.Minute)        // Cache-Control: max-age=600
+call.CachePrivateFor(1 * time.Minute)  // ...and only in the browser that asked for it
+call.NoStore()                         // ...and nowhere at all
+```
+
+- `CacheFor` says how long, and nothing about who — a shared cache decides that for itself.
+  `CachePrivateFor` is the shape a response behind a login needs, and `NoStore` the one for a body
+  that must not outlive the request.
+- Whichever you call last is the one that answers, so a lifetime declared for a group can be
+  overridden by the single route that must not be stored.
+- Declare it where you know what you are answering. One declared up front — in a `Before` handler,
+  say — lands on whatever that route ends up sending, and an explicit lifetime is exactly what makes
+  a 404 or a 500 storable and reusable for its duration.
+- A 304 carries the lifetime too: revalidating renews the stored copy instead of leaving the client
+  asking on every reuse.
+- No `Expires` is sent. Wherever both appear, `max-age` is the one every cache since HTTP/1.1 reads.
+
+Static mounts declare no lifetime unless you ask for one. A validator is advisory, but a lifetime is
+a promise — an asset served an hour out of date is not something to inherit from a framework — and
+nothing govalin knows about a directory says how long its files stay current. One line says it:
+
+```go
+app.Static("/assets", func(_ *govalin.Call, config *govalin.StaticConfig) {
+	config.WithFS(assets).CacheFor(time.Hour)
+})
+```
+
+That is what turns an embedded bundle from one round trip per asset per page load into none. It
+covers every file the mount serves, `index.html` included, so a shell that has to reach clients on
+the next deploy wants a short one.
 
 ## Testing your app
 

--- a/docs/adr/0010-opt-in-freshness-headers.md
+++ b/docs/adr/0010-opt-in-freshness-headers.md
@@ -20,7 +20,16 @@ rather than one read off the lifetime. All three write the one header with `Set`
 the last one called is the one that answers and a default declared for a group in a `Before` handler
 is overridable by the single route that must not be stored.
 
-Static mounts declare **nothing by default**, which is the opposite of the **Derived validator** and
+A **SPA mount's shell is the exception**, and the one place govalin declares freshness without being
+asked: `index.html` is served `no-cache` whatever the mount says, at the mount root, at its own URL
+and at every client-side route the fallback answers. A lifetime on the shell is not the usual trade
+of staleness against round trips — the shell names the fingerprinted bundles, so a client reusing an
+old one asks for assets the deploy replaced, and a mount whose fallback serves it everywhere makes a
+stale copy the whole application. `no-cache` rather than `no-store` because the **Derived validator**
+is already there: the client keeps its copy and is told to keep it, so being never stale costs a 304.
+Outside SPA mode there is no shell to make an exception of, so `index.html` is a file like any other.
+
+Static mounts otherwise declare **nothing by default**, which is the opposite of the **Derived validator** and
 deliberately so. A validator is advisory: a client that ignores it loses a round trip. A lifetime is
 binding: the asset is served stale for its full duration out of a cache the server cannot reach, and
 no deploy takes that back. Nothing govalin knows about a directory says how long its files stay
@@ -37,10 +46,10 @@ serves.
 - **A default lifetime for static mounts** — the value that makes an embedded bundle fast is the same
   value that serves a stale shell after a deploy, and no value is right without knowing what is in
   the directory. A framework guessing here is guessing with a promise it cannot withdraw.
-- **Excluding `index.html` from a mount's lifetime** — the footgun is real, since the shell is what a
-  deploy has to reach. But a mount that silently means "every file except one" is harder to reason
-  about than one that means what it says, and the shell is not always the file that matters. It is
-  documented instead.
+- **Excluding `index.html` from every mount's lifetime** — a plain mount has no shell: `index.html`
+  is a file like any other there, and one that silently meant "every file except one" would be harder
+  to reason about than one that means what it says. Rejected outside SPA mode, where the exclusion is
+  instead the whole point (below).
 - **`public` on `CacheFor`** — the bare `max-age` form deliberately leaves a response to an
   authenticated request unstorable by shared caches (RFC 9111 §3.5). `public` is what overrides that,
   and it is not something a method named for a duration should do without being asked.
@@ -67,9 +76,9 @@ serves.
   error response storable. Clearing it on an error status was rejected: `no-store` on a 500 is the
   same header and is worth keeping, so the framework cannot tell the two apart without inspecting a
   value the caller chose. Documented as a reason to declare a lifetime where the answer is known.
-- A SPA mount's fallback is served through the same path, so the shell is stored under whichever URL
-  asked for it. A route added at that URL later is masked until the lifetime runs out, which is the
-  argument for a short one on a mount serving a shell.
+- A SPA mount's fallback is stored under whichever URL asked for it, which is why the shell is
+  `no-cache` and not merely short-lived: a lifetime there would mask a route added at that URL later
+  for its full duration, on a response served at every URL the app routes.
 - A mount cannot declare a lifetime of zero: the zero value is what "no lifetime" is, and telling the
   two apart would cost a field for a case nobody has asked for. Said from a `Before` handler it still
   reaches the response, since a mount overrides only a lifetime it was configured with.

--- a/docs/adr/0010-opt-in-freshness-headers.md
+++ b/docs/adr/0010-opt-in-freshness-headers.md
@@ -1,0 +1,78 @@
+# Opt-in freshness headers
+
+## Status
+
+accepted
+
+## Context and decision
+
+ADR 0009 made a revalidation cheap. It did not make it unnecessary: the client still asks. Without a
+freshness header a browser has to guess how long a response stays current, and the heuristic it
+guesses with is a fraction of the age since `Last-Modified` — which an embedded asset does not have,
+because `embed.FS` reports the zero time and `http.ServeContent` omits the header. So an embedded
+bundle is revalidated on **every** page load: twenty assets, twenty round trips, twenty 304s. On a
+fast connection that latency is the larger of the two costs, and a validator does not touch it.
+
+**Freshness** is the other half. `call.CacheFor(10 * time.Minute)` writes `Cache-Control: max-age=600`
+and the client reuses its own copy without asking at all. `CachePrivateFor` adds `private` for a
+response behind a login, and `NoStore` refuses storage outright — a **Cache scope** the caller states
+rather than one read off the lifetime. All three write the one header with `Set`, so
+the last one called is the one that answers and a default declared for a group in a `Before` handler
+is overridable by the single route that must not be stored.
+
+Static mounts declare **nothing by default**, which is the opposite of the **Derived validator** and
+deliberately so. A validator is advisory: a client that ignores it loses a round trip. A lifetime is
+binding: the asset is served stale for its full duration out of a cache the server cannot reach, and
+no deploy takes that back. Nothing govalin knows about a directory says how long its files stay
+current, so the mount says it in one line — `config.CacheFor(time.Hour)` — covering every file it
+serves.
+
+## Considered options
+
+- **`Cache-Control` alone, and no default lifetime for static (chosen)** — see above.
+- **Sending `Expires` alongside `max-age`** — the header this feature was filed under, and dead
+  weight. RFC 9111 §5.3 has a recipient ignore `Expires` whenever `max-age` is present, so it is read
+  only by a cache that speaks no HTTP/1.1 at all, and reaching that cache costs a clock read and an
+  IMF-fixdate format on every response that declares a lifetime.
+- **A default lifetime for static mounts** — the value that makes an embedded bundle fast is the same
+  value that serves a stale shell after a deploy, and no value is right without knowing what is in
+  the directory. A framework guessing here is guessing with a promise it cannot withdraw.
+- **Excluding `index.html` from a mount's lifetime** — the footgun is real, since the shell is what a
+  deploy has to reach. But a mount that silently means "every file except one" is harder to reason
+  about than one that means what it says, and the shell is not always the file that matters. It is
+  documented instead.
+- **`public` on `CacheFor`** — the bare `max-age` form deliberately leaves a response to an
+  authenticated request unstorable by shared caches (RFC 9111 §3.5). `public` is what overrides that,
+  and it is not something a method named for a duration should do without being asked.
+- **A freshness argument on `NotModified`** — one call for both halves, and wrong: the halves are
+  independent. A response can be fresh without a validator and validated without a lifetime, and
+  pairing them in the signature would make the common static case pass a value it does not have.
+- **`immutable`** — safe only when the URL is content-addressed (`app.a3f2c1.js`). Govalin does not
+  fingerprint assets, so it belongs to an asset-pipeline discussion, not this one.
+- **`Vary`** — adjacent, and a different question: which stored response may answer a request, rather
+  than how long any of them lasts. Its own issue.
+
+## Consequences
+
+- Freshness composes with validation without either knowing about the other. A 304 carries the
+  `Cache-Control` the 200 would have, so a revalidation renews the stored copy instead of leaving the
+  client asking on every reuse — the status flush drops only the headers describing a representation
+  (ADR 0009), and a lifetime is not one of them.
+- A mount that declares a lifetime serves stale files for its duration, and there is no
+  server-side way to withdraw one. That is the cost the opt-in buys deliberately.
+- A generated directory listing gets no lifetime, for the same reason it gets no validator: it is
+  answered by `http.FileServer` and never passes through `Call`.
+- A lifetime is a header like any other, so one declared before the handler ran lands on whatever
+  that route ends up answering — a 404 or a 500 included, and an explicit lifetime is what makes an
+  error response storable. Clearing it on an error status was rejected: `no-store` on a 500 is the
+  same header and is worth keeping, so the framework cannot tell the two apart without inspecting a
+  value the caller chose. Documented as a reason to declare a lifetime where the answer is known.
+- A SPA mount's fallback is served through the same path, so the shell is stored under whichever URL
+  asked for it. A route added at that URL later is masked until the lifetime runs out, which is the
+  argument for a short one on a mount serving a shell.
+- A mount cannot declare a lifetime of zero: the zero value is what "no lifetime" is, and telling the
+  two apart would cost a field for a case nobody has asked for. Said from a `Before` handler it still
+  reaches the response, since a mount overrides only a lifetime it was configured with.
+- `s-maxage`, `must-revalidate` and `stale-while-revalidate` are not offered. Each is a real answer to
+  a question nobody has asked here yet, and `call.Header` remains available to anyone who needs one.
+- Nothing sends `Expires`, so a cache that reads only that header sees what it saw before this change.

--- a/freshness.go
+++ b/freshness.go
@@ -27,6 +27,13 @@ func (call *Call) CachePrivateFor(duration time.Duration) {
 	call.w.Header().Set(headers.CacheControl, "private, max-age="+maxAgeSeconds(duration))
 }
 
+// NoCache has the client keep the response but check before every reuse, which
+// is what an entry point naming versioned resources needs: never stale, and —
+// paired with a validator — answered by a 304 rather than a body.
+func (call *Call) NoCache() {
+	call.w.Header().Set(headers.CacheControl, "no-cache")
+}
+
 // NoStore forbids storing the response at all, for a body that must not outlive
 // the request that asked for it.
 func (call *Call) NoStore() {

--- a/freshness.go
+++ b/freshness.go
@@ -1,0 +1,43 @@
+package govalin
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/pkkummermo/govalin/internal/http/headers"
+)
+
+// CacheFor declares how long the response stays fresh. Until that runs out the
+// client reuses its stored copy without asking again.
+//
+// A duration under a second, or a negative one, declares a lifetime of zero:
+// the response may be stored, but is revalidated before every reuse.
+//
+// Nothing here says who may store the response — a shared cache decides that
+// for itself, which is what CachePrivateFor and NoStore are for. Whichever of
+// the three is called last is the one that answers.
+func (call *Call) CacheFor(duration time.Duration) {
+	call.w.Header().Set(headers.CacheControl, "max-age="+maxAgeSeconds(duration))
+}
+
+// CachePrivateFor is CacheFor for a response only the client that asked for it
+// may store: fresh in that browser, held by no cache in between. This is the
+// shape an authenticated response needs.
+func (call *Call) CachePrivateFor(duration time.Duration) {
+	call.w.Header().Set(headers.CacheControl, "private, max-age="+maxAgeSeconds(duration))
+}
+
+// NoStore forbids storing the response at all, for a body that must not outlive
+// the request that asked for it.
+func (call *Call) NoStore() {
+	call.w.Header().Set(headers.CacheControl, "no-store")
+}
+
+func maxAgeSeconds(duration time.Duration) string {
+	seconds := int64(duration / time.Second)
+	if seconds < 0 {
+		seconds = 0
+	}
+
+	return strconv.FormatInt(seconds, 10)
+}

--- a/freshness_test.go
+++ b/freshness_test.go
@@ -75,6 +75,30 @@ func TestCachePrivateForKeepsAResponseOutOfSharedCaches(t *testing.T) {
 	})
 }
 
+// TestNoCacheKeepsTheStoredCopyButAsksAnyway covers the shape an entry point
+// needs: the client keeps the response, and finds out it is still current with
+// a 304 rather than a download.
+func TestNoCacheKeepsTheStoredCopyButAsksAnyway(t *testing.T) {
+	app := newTestApp()
+	app.Get("/index", func(call *govalin.Call) {
+		call.NoCache()
+
+		if call.NotModified("v3") {
+			return
+		}
+
+		call.HTML("the shell")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.GetResponse("/index")
+		assert.Equal(t, "no-cache", response.Header.Get("Cache-Control"), "Should have the client ask every time")
+
+		revalidated := revalidate(t, client, http.MethodGet, "/index", `"v3"`)
+		assert.Equal(t, http.StatusNotModified, revalidated.StatusCode, "Asking should cost headers, not a body")
+	})
+}
+
 func TestNoStoreForbidsStoringTheResponse(t *testing.T) {
 	app := newTestApp()
 	app.Get("/token", func(call *govalin.Call) {

--- a/freshness_test.go
+++ b/freshness_test.go
@@ -1,0 +1,147 @@
+package govalin_test
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pkkummermo/govalin"
+	"github.com/pkkummermo/govalin/govalintest"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCacheForDeclaresFreshness(t *testing.T) {
+	app := newTestApp()
+	app.Get("/asset", func(call *govalin.Call) {
+		call.CacheFor(10 * time.Minute)
+		call.Text("the asset")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.GetResponse("/asset")
+
+		assert.Equal(t, "max-age=600", response.Header.Get("Cache-Control"), "Should declare the lifetime in seconds")
+		assert.Equal(t, "the asset", readBody(t, response), "Should serve the representation")
+	})
+}
+
+// TestCacheForFloorsAtZero covers the two durations that cannot be a lifetime:
+// max-age counts whole seconds, and a negative one is not a valid header value.
+// Both mean the client has to ask, which is what a zero says.
+func TestCacheForFloorsAtZero(t *testing.T) {
+	durations := map[string]time.Duration{
+		"/sub-second": 900 * time.Millisecond,
+		"/negative":   -time.Hour,
+	}
+
+	app := newTestApp()
+
+	for path, duration := range durations {
+		app.Get(path, func(call *govalin.Call) {
+			call.CacheFor(duration)
+			call.Text("the asset")
+		})
+	}
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		for path := range durations {
+			response := client.GetResponse(path)
+
+			assert.Equal(
+				t,
+				"max-age=0",
+				response.Header.Get("Cache-Control"),
+				"A %s duration should be a lifetime of zero", strings.TrimPrefix(path, "/"),
+			)
+		}
+	})
+}
+
+// TestCachePrivateForKeepsAResponseOutOfSharedCaches covers the case an
+// authenticated response needs: fresh in the browser that asked for it, stored
+// by nothing in between.
+func TestCachePrivateForKeepsAResponseOutOfSharedCaches(t *testing.T) {
+	app := newTestApp()
+	app.Get("/me", func(call *govalin.Call) {
+		call.CachePrivateFor(time.Minute)
+		call.Text("your profile")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.GetResponse("/me")
+
+		assert.Equal(t, "private, max-age=60", response.Header.Get("Cache-Control"), "Should name one cache only")
+	})
+}
+
+func TestNoStoreForbidsStoringTheResponse(t *testing.T) {
+	app := newTestApp()
+	app.Get("/token", func(call *govalin.Call) {
+		call.NoStore()
+		call.Text("the token")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.GetResponse("/token")
+
+		assert.Equal(t, "no-store", response.Header.Get("Cache-Control"), "Should forbid storing the response")
+	})
+}
+
+// TestFreshnessReplacesAnEarlierDeclaration covers a group-wide default being
+// overridden by the one route that must not be stored. Two Cache-Control values
+// on one response are read as one list, so appending would leave the response
+// both cacheable and not.
+func TestFreshnessReplacesAnEarlierDeclaration(t *testing.T) {
+	app := newTestApp()
+	app.Before("/api/*", func(call *govalin.Call) bool {
+		call.CacheFor(time.Hour)
+
+		return true
+	})
+	app.Get("/api/token", func(call *govalin.Call) {
+		call.NoStore()
+		call.Text("the token")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.GetResponse("/api/token")
+
+		assert.Equal(
+			t,
+			[]string{"no-store"},
+			response.Header.Values("Cache-Control"),
+			"The last declaration should be the only one",
+		)
+	})
+}
+
+// TestFreshnessSurvivesARevalidation covers what a 304 is for once freshness is
+// declared: the client stored the response, came back when it went stale, and
+// the answer has to renew the lifetime or it revalidates on every request from
+// here on.
+func TestFreshnessSurvivesARevalidation(t *testing.T) {
+	app := newTestApp()
+	app.Get("/asset", func(call *govalin.Call) {
+		call.CacheFor(10 * time.Minute)
+
+		if call.NotModified("v3") {
+			return
+		}
+
+		call.Text("the asset")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := revalidate(t, client, http.MethodGet, "/asset", `"v3"`)
+
+		assert.Equal(t, http.StatusNotModified, response.StatusCode, "Should answer 304 on a match")
+		assert.Equal(
+			t,
+			"max-age=600",
+			response.Header.Get("Cache-Control"),
+			"A 304 should renew the lifetime of the stored response",
+		)
+	})
+}

--- a/static.go
+++ b/static.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"strings"
 	"sync"
+	"time"
 )
 
 // StaticConfig contains configuration for a static handler.
@@ -21,6 +22,7 @@ type StaticConfig struct {
 	spaMode    bool
 	staticPath string
 	fsContent  fs.FS
+	cacheFor   time.Duration
 	validators *sync.Map
 }
 
@@ -30,6 +32,7 @@ func newStaticConfig(validators *sync.Map) *StaticConfig {
 		spaMode:    false,
 		staticPath: "static",
 		fsContent:  nil,
+		cacheFor:   0,
 		validators: validators,
 	}
 }
@@ -117,6 +120,10 @@ func (config *StaticConfig) serveFile(call *Call, hostedFileSystem fs.FS, name s
 	fileInfo, statErr := file.Stat()
 	if statErr != nil {
 		return statErr
+	}
+
+	if config.cacheFor > 0 {
+		call.CacheFor(config.cacheFor)
 	}
 
 	// Both sinks revalidate the same way; http.ServeContent covers only the seekable one.
@@ -265,6 +272,19 @@ func (config *StaticConfig) WithStaticPath(staticPath string) *StaticConfig {
 // WithFS sets the bundled FS to serve static files from.
 func (config *StaticConfig) WithFS(fsContent fs.FS) *StaticConfig {
 	config.fsContent = fsContent
+
+	return config
+}
+
+// CacheFor declares how long the files this mount serves stay fresh, which is
+// what stops a client revalidating every asset on every page load. A mount
+// declares nothing until asked, and only a positive duration asks.
+//
+// It covers every file the mount serves, index.html and the SPA fallback
+// included, so a bundle whose shell must reach clients on the next deploy wants
+// a short one.
+func (config *StaticConfig) CacheFor(duration time.Duration) *StaticConfig {
+	config.cacheFor = duration
 
 	return config
 }

--- a/static.go
+++ b/static.go
@@ -122,7 +122,10 @@ func (config *StaticConfig) serveFile(call *Call, hostedFileSystem fs.FS, name s
 		return statErr
 	}
 
-	if config.cacheFor > 0 {
+	switch {
+	case config.spaMode && path.Base(name) == indexFileName:
+		call.NoCache()
+	case config.cacheFor > 0:
 		call.CacheFor(config.cacheFor)
 	}
 
@@ -280,9 +283,9 @@ func (config *StaticConfig) WithFS(fsContent fs.FS) *StaticConfig {
 // what stops a client revalidating every asset on every page load. A mount
 // declares nothing until asked, and only a positive duration asks.
 //
-// It covers every file the mount serves, index.html and the SPA fallback
-// included, so a bundle whose shell must reach clients on the next deploy wants
-// a short one.
+// It covers every file the mount serves, index.html included — except on a SPA
+// mount, whose shell is always checked before it is reused, whatever lifetime
+// the assets it names are given.
 func (config *StaticConfig) CacheFor(duration time.Duration) *StaticConfig {
 	config.cacheFor = duration
 
@@ -293,6 +296,10 @@ func (config *StaticConfig) CacheFor(duration time.Duration) *StaticConfig {
 //
 // SPA mode will serve the index.html file for all requests that doesn't match
 // a static file.
+//
+// That shell is served with no freshness of its own, whatever CacheFor declares
+// for the mount: it names the bundles a deploy replaces, so a client reusing an
+// old copy asks for assets that are no longer there.
 func (config *StaticConfig) EnableSPAMode(spaMode bool) *StaticConfig {
 	config.spaMode = spaMode
 

--- a/static_test.go
+++ b/static_test.go
@@ -362,6 +362,91 @@ func TestStaticCacheForAppliesToEveryFileTheMountServes(t *testing.T) {
 	})
 }
 
+// TestStaticSPAShellIsNeverFresh covers the one file a SPA mount must not
+// promise anything about. The shell names the hashed bundles, so a client
+// holding an old one asks for assets a deploy has already replaced — and it is
+// served at every URL the app routes, so a stale copy is the whole app.
+func TestStaticSPAShellIsNeverFresh(t *testing.T) {
+	bundle := fstest.MapFS{
+		"index.html":      &fstest.MapFile{Data: []byte("shell")},
+		"assets/app.js":   &fstest.MapFile{Data: []byte("bundled")},
+		"docs/index.html": &fstest.MapFile{Data: []byte("docs shell")},
+	}
+
+	app := newTestApp()
+	app.Static("/spa", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithFS(bundle).EnableSPAMode(true).CacheFor(time.Hour)
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		shellURLs := []string{"/spa/index.html", "/spa/", "/spa/some/client/route", "/spa/docs/"}
+		for _, shellURL := range shellURLs {
+			assert.Equal(
+				t,
+				"no-cache",
+				client.GetResponse(shellURL).Header.Get("Cache-Control"),
+				"The shell served at %s should be checked on every use",
+				shellURL,
+			)
+		}
+
+		asset := client.GetResponse("/spa/assets/app.js")
+		assert.Equal(
+			t,
+			"max-age=3600",
+			asset.Header.Get("Cache-Control"),
+			"What the shell points at is what the mount's lifetime is for",
+		)
+	})
+}
+
+// TestStaticSPAShellRevalidatesCheaply is what makes a shell that is never
+// fresh affordable: the client keeps its copy and is told to keep it, so
+// checking costs headers rather than the bundle.
+func TestStaticSPAShellRevalidatesCheaply(t *testing.T) {
+	bundle := fstest.MapFS{"index.html": &fstest.MapFile{Data: []byte("shell")}}
+
+	app := newTestApp()
+	app.Static("/spa", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithFS(bundle).EnableSPAMode(true)
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		served := client.GetResponse("/spa/")
+
+		assert.Equal(
+			t,
+			"no-cache",
+			served.Header.Get("Cache-Control"),
+			"A SPA mount that declared no lifetime should still keep its shell out of a heuristic",
+		)
+
+		revalidated := revalidate(t, client, http.MethodGet, "/spa/", served.Header.Get("ETag"))
+		assert.Equal(t, http.StatusNotModified, revalidated.StatusCode, "Checking should be answered with a 304")
+		assert.Empty(t, readBody(t, revalidated), "A 304 should carry no shell")
+	})
+}
+
+// TestStaticIndexKeepsTheMountLifetimeWithoutSPAMode pins the scope of that
+// exception. Outside SPA mode a mount has no shell — index.html is a file like
+// any other, and a mount that quietly meant "every file except one" would be
+// harder to reason about than one that means what it says.
+func TestStaticIndexKeepsTheMountLifetimeWithoutSPAMode(t *testing.T) {
+	app := newTestApp()
+	app.Static("/static", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithStaticPath("internal/testdata/static").CacheFor(time.Hour)
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		assert.Equal(
+			t,
+			"max-age=3600",
+			client.GetResponse("/static/index.html").Header.Get("Cache-Control"),
+			"A plain mount serves index.html under the lifetime it declared",
+		)
+	})
+}
+
 // TestStaticLeavesTheFileServerItsWork pins the other half of that split: a
 // directory with no index.html is still the file server's to list, and a
 // directory reached without its trailing slash is still its to redirect.

--- a/static_test.go
+++ b/static_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 	"testing/fstest"
+	"time"
 
 	"github.com/pkkummermo/govalin"
 	"github.com/pkkummermo/govalin/govalintest"
@@ -276,6 +277,86 @@ func TestStaticDerivesValidatorsForDirectoryIndexes(t *testing.T) {
 				revalidated.StatusCode,
 				"Revalidating %s should be answered with a 304",
 				mountRoot,
+			)
+		}
+	})
+}
+
+// TestStaticSendsNoFreshnessByDefault pins the asymmetry between the two halves
+// of caching a static mount. A validator is advisory, so it is derived without
+// being asked; a lifetime is a promise the client holds the framework to, and
+// nothing govalin knows about a directory says how long its files stay current.
+func TestStaticSendsNoFreshnessByDefault(t *testing.T) {
+	staticRoot, _ := fs.Sub(staticTestFiles, "internal/testdata/static")
+
+	app := newTestApp()
+	app.Static("/fs", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithFS(staticRoot)
+	})
+	app.Static("/static", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithStaticPath("internal/testdata/static")
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		for _, mount := range []string{"/fs", "/static"} {
+			served := client.GetResponse(mount + "/index.html")
+
+			assert.NotEmpty(t, served.Header.Get("ETag"), "A file on %s should still be validated", mount)
+			assert.Empty(
+				t,
+				served.Header.Get("Cache-Control"),
+				"A file on %s should promise no lifetime nobody asked for",
+				mount,
+			)
+		}
+	})
+}
+
+// TestStaticCacheForAppliesToEveryFileTheMountServes covers the one line that
+// turns a bundle from one round trip per asset per page load into none: the
+// mount's lifetime reaches the files below it, the index a directory serves,
+// and the 304 that renews a stored copy.
+func TestStaticCacheForAppliesToEveryFileTheMountServes(t *testing.T) {
+	staticRoot, _ := fs.Sub(staticTestFiles, "internal/testdata/static")
+
+	app := newTestApp()
+	app.Static("/fs", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithFS(staticRoot).CacheFor(time.Hour)
+	})
+	app.Static("/static", func(_ *govalin.Call, staticConfig *govalin.StaticConfig) {
+		staticConfig.WithStaticPath("internal/testdata/static").CacheFor(time.Hour)
+	})
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		for _, mount := range []string{"/fs", "/static"} {
+			for _, path := range []string{"/sub/test.html", "/"} {
+				served := client.GetResponse(mount + path)
+
+				assert.Equal(
+					t,
+					"max-age=3600",
+					served.Header.Get("Cache-Control"),
+					"%s%s should carry the lifetime its mount declared",
+					mount, path,
+				)
+			}
+
+			etag := client.GetResponse(mount + "/index.html").Header.Get("ETag")
+			revalidated := revalidate(t, client, http.MethodGet, mount+"/index.html", etag)
+
+			assert.Equal(
+				t,
+				http.StatusNotModified,
+				revalidated.StatusCode,
+				"A client on %s that comes back with the validator should get a 304",
+				mount,
+			)
+			assert.Equal(
+				t,
+				"max-age=3600",
+				revalidated.Header.Get("Cache-Control"),
+				"A 304 from %s should renew the lifetime of the stored copy",
+				mount,
 			)
 		}
 	})


### PR DESCRIPTION
Closes #83.

A validator makes a revalidation cheap; only freshness makes it unnecessary. An embedded bundle
sends no `Last-Modified`, so today every asset is revalidated on every page load — twenty assets,
twenty round trips, twenty 304s — and ADR 0009 could not touch that.

- `call.CacheFor(d)`, `CachePrivateFor(d)`, `NoCache()`, `NoStore()` for handlers. All write the one
  header, so the last call wins.
- `config.CacheFor(d)` for a static mount, **off unless asked for**. A validator is advisory, a
  lifetime is binding: it cannot be withdrawn from a cache the server never sees, and nothing govalin
  knows about a directory says how long its files stay current.
- A SPA mount's `index.html` is `no-cache` whatever the mount declares. It names the fingerprinted
  bundles and is served at every URL the app routes, so a stored copy is not one stale asset but the
  whole application asking for files a deploy has replaced. `no-cache` and not `no-store` because the
  derived validator is already there — never stale costs a 304, not the bundle.

**No `Expires`**, despite the issue title. RFC 9111 §5.3 has a recipient ignore it wherever `max-age`
is present, so it reaches only a cache that speaks no HTTP/1.1 at all, at the cost of a clock read
and a date format on every response that declares a lifetime. Reasoning and the rest of the
decisions — including why an error response can inherit a lifetime declared before the handler ran,
and why clearing it would be worse — are in [ADR 0010](docs/adr/0010-opt-in-freshness-headers.md).

`Vary` was decided out of scope and is now #94. Checking what govalin already did with it turned up
#95: the CORS plugin sends `Vary: Access-Control-Allow-Origin`, a response header, where `Vary` names
request headers.

Allocation budgets are unchanged — a mount that declares nothing pays nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)