### PR TITLE
fix(cors): vary on Origin, the header the response was selected from

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -293,6 +293,13 @@ a login is a scope decision and a lifetime decision, answered deliberately rathe
 each other.
 _Avoid_: `public` as a synonym for cacheable, a scope read off how long something stays fresh
 
+**Selecting header**:
+The request header a response was chosen from, which is what `Vary` names — and only a request header
+can be one. A response header put there names nothing a request carries, so the cache keys on the URL
+alone and a single stored copy answers everyone. Naming a header the answer does not depend on is the
+opposite mistake, and costs storage rather than correctness.
+_Avoid_: a response header in `Vary`, a `Vary` sent only on the responses that came out varying
+
 **Implied HEAD**:
 A HEAD answered by the route's GET handler, because HEAD is GET without a body. A handler registered
 for HEAD replaces it wherever it sits in the route table — that is how a route buys the right to skip
@@ -381,6 +388,10 @@ routing that assumes upstream path cleanup
   the length are already on the response its GET handler produces
 - An **Implied HEAD** is logged as the HEAD it is; that a GET handler answered it is routing, not
   something the client did
+- A **Selecting header** is what a cache keys on in addition to the URL, so it is declared by every
+  response the plugin reading it produced — including the one it declined to add CORS headers to
+- **Freshness** decides how long a missing **Selecting header** goes on answering the wrong request:
+  a stored response with a lifetime is reused rather than revalidated
 
 ## Example dialogue
 
@@ -394,3 +405,4 @@ routing that assumes upstream path cleanup
 - Existing HTTP->HTTPS plugin redirect currently uses only URL path and drops query parameters; resolved: query-preserving behavior applies framework-wide and this behavior must be aligned.
 - "ETag support" was used to mean both cache validation and optimistic concurrency control; resolved: this work is cache validation only, and a precondition on an unsafe method is a separate feature that would need its own name.
 - "caching" was used to mean both freshness and cache validation; resolved: they are the two halves of caching, and a request that never happens is the one freshness is for.
+- `Vary` was read as naming the headers a response carries; resolved: it names the request headers the response was selected from, and a response header there is a cache key of nothing.

--- a/docs/adr/0011-vary-on-origin.md
+++ b/docs/adr/0011-vary-on-origin.md
@@ -1,0 +1,48 @@
+# Vary on Origin for every response the CORS plugin sees
+
+## Status
+
+accepted
+
+## Context and decision
+
+The plugin sent `Vary: Access-Control-Allow-Origin`. `Vary` names the **request** headers a response
+was selected from, and that is a response header — so the value named a header no request carries, a
+cache keyed on nothing, and one stored response answered every origin. The response does vary on
+`Origin`: the requesting origin is written straight into `Access-Control-Allow-Origin`. The header
+is `Vary: Origin`.
+
+It is sent **before the allowed-origin check**, so a rejected origin gets it too. That response is as
+wrong to reuse as an accepted one's — stored without `Vary`, the bare answer given to an origin the
+config excludes is handed to the next request from an origin it permits, and the browser blocks a
+request the server was willing to allow. What the response was selected from is the `Origin` header,
+not whether the plugin liked what it read there.
+
+A **preflight** names no further selecting header. `Access-Control-Request-Method` and
+`Access-Control-Request-Headers` are request headers, and a preflight answer built out of them would
+be selected from them — but this plugin answers from its configuration: the allowed methods and
+headers are the same list whatever the preflight asked for. Naming a header the answer does not
+depend on splits a cache's storage per requested method-and-header combination and buys nothing back.
+
+## Considered options
+
+- **`Vary: Origin`, sent unconditionally, and nothing else (chosen)** — see above.
+- **Adding the two `Access-Control-Request-*` headers on preflights** — correct for a plugin that
+  echoes the requested method and headers back, which is what the advice to send them assumes and what
+  this one does not do. It becomes the right answer the day the preflight response is computed from
+  the preflight request; until then it declares a dependency that isn't there.
+- **Sending `Vary` only once the origin is allowed** — the narrow reading of "this response varies",
+  and it leaves the rejected answer cacheable under a key that ignores the header it was chosen by.
+  The disallowed case is the one where the missing `Vary` is invisible, since neither response carries
+  a CORS header to notice the mix-up by.
+
+## Consequences
+
+- Every response from an app with the plugin installed carries `Vary: Origin`, whether or not it has
+  anything to do with CORS — the plugin's before handler runs on `*`. A shared cache stores a copy per
+  origin, which is the true cost of a response header derived from a request header.
+- `call.Header` adds rather than sets, so a handler that declares its own `Vary` sends a second field
+  line rather than replacing this one. Both are read, per RFC 9110 §5.3.
+- Freshness (ADR 0010) is what makes the reuse window long enough to matter: a response with a
+  declared lifetime is one a cache serves again rather than revalidates, so the response that gets
+  handed to the wrong origin is handed over for the full lifetime.

--- a/plugins/cors/cors.go
+++ b/plugins/cors/cors.go
@@ -70,12 +70,16 @@ func (config *Config) checkConfiguration() {
 func (config *Config) handleCors(call *govalin.Call) bool {
 	origin := call.Header(headers.Origin)
 
-	if !util.ContainsSome(config.allowedOrigins, wildcard, origin) {
+	// Declared before the origin check: the response was selected from Origin either way (ADR 0011).
+	call.Header(headers.Vary, headers.Origin)
+
+	// A request with no Origin is not a CORS request; the wildcard would otherwise allow it and
+	// echo an empty origin back.
+	if origin == "" || !util.ContainsSome(config.allowedOrigins, wildcard, origin) {
 		return true
 	}
 
 	call.Header(headers.AccessControlAllowOrigin, origin)
-	call.Header(headers.Vary, headers.AccessControlAllowOrigin)
 
 	if util.ContainsSome(config.allowedHeaders, wildcard) {
 		call.Header(headers.AccessControlAllowHeaders, wildcard)

--- a/plugins/cors/cors_test.go
+++ b/plugins/cors/cors_test.go
@@ -123,6 +123,77 @@ func TestShouldHaveDefaultsEnabledForSimpleConfiguration(t *testing.T) {
 	})
 }
 
+func TestVaryOnOriginOnPreflightAndActualRequest(t *testing.T) {
+	app := govalin.New(func(config *govalin.Config) {
+		config.Plugin(cors.New().AllowAllOrigins())
+	}).Get("/govalin", func(call *govalin.Call) { call.Text("govalin") })
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		preflight, err := http.NewRequest(http.MethodOptions, "/govalin", nil)
+		assert.Nil(t, err)
+		preflight.Header.Set(headers.Origin, "http://govalin.io")
+		preflight.Header.Set(headers.AccessControlRequestMethod, http.MethodGet)
+		preflight.Header.Set(headers.AccessControlRequestHeaders, "my-special-header")
+		response := client.Do(preflight)
+		defer func() { _ = response.Body.Close() }()
+
+		assert.Equal(t, []string{headers.Origin}, response.Header.Values(headers.Vary))
+
+		actual, err := http.NewRequest(http.MethodGet, "/govalin", nil)
+		assert.Nil(t, err)
+		actual.Header.Set(headers.Origin, "http://govalin.io")
+		response = client.Do(actual)
+		defer func() { _ = response.Body.Close() }()
+
+		assert.Equal(t, []string{headers.Origin}, response.Header.Values(headers.Vary))
+	})
+}
+
+func TestVaryOnOriginWhenOriginIsNotAllowed(t *testing.T) {
+	app := govalin.New(func(config *govalin.Config) {
+		config.Plugin(cors.New().AllowOrigins("http://govalin.io"))
+	}).Get("/govalin", func(call *govalin.Call) { call.Text("govalin") })
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		req, err := http.NewRequest(http.MethodGet, "/govalin", nil)
+		assert.Nil(t, err)
+		req.Header.Set(headers.Origin, "http://nogovalin.io")
+		response := client.Do(req)
+		defer func() { _ = response.Body.Close() }()
+
+		assert.Equal(t, "", response.Header.Get(headers.AccessControlAllowOrigin))
+		assert.Equal(t, []string{headers.Origin}, response.Header.Values(headers.Vary))
+	})
+}
+
+func TestVaryOnOriginWhenRequestCarriesNoOrigin(t *testing.T) {
+	app := govalin.New(func(config *govalin.Config) {
+		config.Plugin(cors.New().AllowAllOrigins())
+	}).Get("/govalin", func(call *govalin.Call) { call.Text("govalin") })
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.GetResponse("/govalin")
+		defer func() { _ = response.Body.Close() }()
+
+		assert.Equal(t, []string{headers.Origin}, response.Header.Values(headers.Vary))
+	})
+}
+
+func TestNoCorsHeadersWhenRequestCarriesNoOrigin(t *testing.T) {
+	app := govalin.New(func(config *govalin.Config) {
+		config.Plugin(cors.New().AllowAllOrigins())
+	}).Get("/govalin", func(call *govalin.Call) { call.Text("govalin") })
+
+	govalintest.Test(t, app, func(client *govalintest.Client) {
+		response := client.GetResponse("/govalin")
+		defer func() { _ = response.Body.Close() }()
+
+		assert.Empty(t, response.Header.Values(headers.AccessControlAllowOrigin))
+		assert.Empty(t, response.Header.Values(headers.AccessControlAllowHeaders))
+		assert.Empty(t, response.Header.Values(headers.AccessControlAllowMethods))
+	})
+}
+
 func TestNotFoundHandlerStillTriggers(t *testing.T) {
 	app := govalin.New(func(config *govalin.Config) {
 		config.Plugin(cors.New().AllowAllOrigins())


### PR DESCRIPTION
`Vary` named `Access-Control-Allow-Origin` — a response header, so it named nothing a request
carries. A shared cache keyed on the URL alone and handed one origin's copy, CORS headers and all,
to the next origin that asked. The value is now `Origin`.

Two things beyond the one-line value fix:

- The header is declared **before** the allowed-origin check. A response the plugin declined to add
  CORS headers to was selected from `Origin` just as much as one it allowed, and reusing that copy
  for a permitted origin blocks a request the server would have allowed. The cost is that every
  response from an app with the plugin installed now carries `Vary: Origin`.
- A request carrying no `Origin` is left alone. The wildcard matched its empty origin, so a
  same-origin request under `AllowAllOrigins()` came back with an empty
  `Access-Control-Allow-Origin:` and both allow lists behind it.

The issue's open question — whether a preflight should also name `Access-Control-Request-Method` and
`Access-Control-Request-Headers` — is answered no: this plugin's preflight answer comes out of its
configuration, not out of the request, so naming them would fragment cache storage per requested
method-and-header combination and buy nothing. ADR 0011 records that, and the condition that would
flip it.

Fixes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)