### PR TITLE
chore: enforce gofumpt via golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,3 +2,7 @@ version: "2"
 
 linters:
   default: standard
+
+formatters:
+  enable:
+    - gofumpt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,10 @@
 # Agent Guidelines
 
+## Formatting
+
+Go code is formatted with **gofumpt**, not gofmt — run `gofumpt -w` on the files you touch. It is
+enforced as a golangci-lint formatter, so gofmt-clean code can still fail lint.
+
 ## Code comments
 
 Govalin is a public library, so an **exported identifier carries a doc comment** — that is the API

--- a/config.go
+++ b/config.go
@@ -42,16 +42,20 @@ type ServerEvents struct {
 	onRouteAdded     []OnRouteAdded
 }
 
-type OnServerStartup func()
-type OnServerShutdown func()
-type OnRouteAdded func(method string, path string, handler HandlerFunc)
+type (
+	OnServerStartup  func()
+	OnServerShutdown func()
+	OnRouteAdded     func(method string, path string, handler HandlerFunc)
+)
 
 func (events *ServerEvents) AddOnServerStartup(event OnServerStartup) {
 	events.onServerStartup = append(events.onServerStartup, event)
 }
+
 func (events *ServerEvents) AddOnServerShutdown(event OnServerShutdown) {
 	events.onServerShutdown = append(events.onServerShutdown, event)
 }
+
 func (events *ServerEvents) AddOnRouteAdded(event OnRouteAdded) {
 	events.onRouteAdded = append(events.onRouteAdded, event)
 }
@@ -120,7 +124,7 @@ func (config *Config) EnableSessions(confFunc ...SessionConfigFunc) *Config {
 		sessionStore:      session.NewInMemoryStore(),
 	}
 
-	if (len(confFunc)) > 0 {
+	if len(confFunc) > 0 {
 		confFunc[0](&configuredSession)
 	}
 

--- a/handlers.go
+++ b/handlers.go
@@ -23,7 +23,6 @@ type pathHandler struct {
 
 func newPathHandlerFromPathFragment(pathFragment string) (pathHandler, error) {
 	pathMatcher, err := routing.NewPathMatcherFromString(pathFragment)
-
 	if err != nil {
 		return pathHandler{}, fmt.Errorf(
 			"failed to create path matcher for pathFragment '%s'. Err: %w", pathFragment, err,

--- a/internal/routing/path-parser.go
+++ b/internal/routing/path-parser.go
@@ -2,10 +2,9 @@ package routing
 
 import (
 	"fmt"
+	"log/slog"
 	"regexp"
 	"strings"
-
-	"log/slog"
 )
 
 type PathMatcher struct {
@@ -35,12 +34,11 @@ func NewPathMatcherFromString(path string) (PathMatcher, error) {
 	}
 
 	pathSegments, err := getPathSegments(path)
-
 	if err != nil {
 		return PathMatcher{}, err
 	}
 
-	var pathParamNames = []string{}
+	pathParamNames := []string{}
 	for _, ps := range pathSegments {
 		pathParamNames = append(pathParamNames, ps.PathNames...)
 	}

--- a/internal/session/in-memory.go
+++ b/internal/session/in-memory.go
@@ -64,7 +64,6 @@ func (s *inMemoryStore) sessionPrune() error {
 // CreateSession creates a new session with the given expiration time and returns its ID.
 func (s *inMemoryStore) CreateSession(expires int64) (string, error) {
 	sessionID, err := CreateNewSessionID(s)
-
 	if err != nil {
 		return "", err
 	}
@@ -107,7 +106,7 @@ func (s *inMemoryStore) GetSessions(time int64) ([]Session, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	var sessions = make([]Session, 0)
+	sessions := make([]Session, 0)
 
 	for _, session := range s.store {
 		if session.Expires > time {

--- a/internal/session/session-store.go
+++ b/internal/session/session-store.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"io"
-
 	"log/slog"
 
 	"github.com/pkkummermo/govalin/internal/util"

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -19,7 +19,8 @@ func GetUnmarshalError(err *json.UnmarshalTypeError) *Error {
 			http.StatusBadRequest,
 			NewParameterErrorDetail(
 				lowerFirst(err.Struct)+"."+err.Field,
-				fmt.Sprintf("Incorrect type. '%s' is not of type '%s'",
+				fmt.Sprintf(
+					"Incorrect type. '%s' is not of type '%s'",
 					err.Value,
 					expectedType,
 				),

--- a/plugins/cors/cors.go
+++ b/plugins/cors/cors.go
@@ -1,11 +1,10 @@
 package cors
 
 import (
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
-
-	"log/slog"
 
 	"github.com/pkkummermo/govalin"
 	"github.com/pkkummermo/govalin/internal/http/headers"

--- a/plugins/logging/structuredLogging.go
+++ b/plugins/logging/structuredLogging.go
@@ -1,9 +1,8 @@
 package logging
 
 import (
-	"os"
-
 	"log/slog"
+	"os"
 
 	"github.com/pkkummermo/govalin"
 )

--- a/plugins/session/sqlitesession/sqlite-session.go
+++ b/plugins/session/sqlitesession/sqlite-session.go
@@ -25,7 +25,6 @@ func (config *Config) Name() string {
 
 func (config *Config) OnInit(conf *govalin.Config) {
 	initiatedStore, err := NewSqliteSessionStore(config.connectionString, config.useWAL)
-
 	if err != nil {
 		slog.Error("Failed to initiate the SQLite session store")
 		os.Exit(1)

--- a/plugins/session/sqlitesession/sqlite-store.go
+++ b/plugins/session/sqlitesession/sqlite-store.go
@@ -72,7 +72,6 @@ func (s *sqliteSessionStore) init() error {
 	defer s.mutex.Unlock()
 
 	initiatedStatements, err := internal.InitStatements(s.db)
-
 	if err != nil {
 		return err
 	}
@@ -84,7 +83,6 @@ func (s *sqliteSessionStore) init() error {
 
 func (s *sqliteSessionStore) CreateSession(expires int64) (string, error) {
 	sessionID, err := session.CreateNewSessionID(s)
-
 	if err != nil {
 		return "", err
 	}

--- a/static.go
+++ b/static.go
@@ -47,7 +47,8 @@ func (config *StaticConfig) serveIndex(call *Call, hostedFileSystem fs.FS) {
 	failStatic(call, config.serveFile(call, hostedFileSystem, indexFileName), fmt.Sprintf(
 		`Failed to serve %s for the static mount on '%s'.
 This might be due to a misconfigured static path or embedded bundle, or simply
-that the %s file doesn't exist.`, indexFileName, config.hostPath, indexFileName))
+that the %s file doesn't exist.`, indexFileName, config.hostPath, indexFileName,
+	))
 }
 
 // failStatic answers a static file that could not be served. A response already

--- a/validation_test.go
+++ b/validation_test.go
@@ -225,7 +225,6 @@ func TestValidatedBody(t *testing.T) {
 			ValidateField("Email").Required().Email().Get().
 			ValidateField("Age").Min(18).Max(100).Get().
 			Get()
-
 		if err != nil {
 			call.Error(err)
 			return
@@ -416,7 +415,6 @@ func TestBodyValidatorCustom(t *testing.T) {
 			ValidateField("Name").Required().MinLength(2).Get().
 			ValidateField("Email").Required().Email().Get().
 			Get()
-
 		if err != nil {
 			call.Error(err)
 			return
@@ -470,7 +468,6 @@ func TestBodyValidatorWithTypedCustom(t *testing.T) {
 				return user.Age >= 13
 			}, "Must be at least 13 years old").
 			Get()
-
 		if err != nil {
 			call.Error(err)
 			return
@@ -529,7 +526,6 @@ func TestCurryableTypedCustomValidation(t *testing.T) {
 				return strings.Contains(u.Email, "@")
 			}, "Email must contain @ symbol").
 			Get()
-
 		if err != nil {
 			call.Error(err)
 			return


### PR DESCRIPTION
The lint config enabled only the standard linter set, which checks `gofmt`. gofumpt's extra rules
were therefore unenforced and had drifted across 12 files.

Two commits, formatting first so the enforcement commit lands on an already-clean tree and neither
commit leaves the repo failing its own lint config:

- `style: format the tree with gofumpt` — mechanical only (blank lines after `err` assignments,
  `log/slog` import grouping, `var x =` → `x :=`, grouped `type` block). No behaviour changes.
- `chore: enforce gofumpt via golangci-lint` — the `formatters:` block, plus a Formatting section in
  `AGENTS.md` so the rule is discoverable without reading the lint config.

Verified the rule is actually live rather than merely configured: a probe file containing
`var x = 1` (gofmt-clean, gofumpt-dirty) was flagged by `golangci-lint fmt --diff`. `go build`,
`go test ./...` and `golangci-lint run ./...` are green.

Note that CI sets `only-new-issues: true`, so it reports on changed lines only — that is why the
drift accumulated silently, and why the reformat commit was needed rather than just flipping the
config on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)