### PR TITLE
build: require Go 1.27

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25.x"
+          go-version: "1.27.x"
       - uses: actions/checkout@v6
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.25.x", "1.26.x"]
+        go-version: ["1.27.x"]
     steps:
       - uses: actions/checkout@v6
 
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.x"
+          go-version: "1.27.x"
 
       - name: Race test
         run: go test -race ./...
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.x"
+          go-version: "1.27.x"
 
       - name: Allocation budget
         env:
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: "1.25.x"
+          go-version: "1.27.x"
 
       - name: Install benchstat
         run: go install golang.org/x/perf/cmd/benchstat@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pkkummermo/govalin
 
-go 1.25.0
+go 1.27.0
 
 require (
 	github.com/ddliu/go-httpclient v0.7.1

--- a/perf_test.go
+++ b/perf_test.go
@@ -36,7 +36,7 @@ var allocationBudgets = []allocationBudget{
 	{
 		name:    "json",
 		target:  "/json",
-		allowed: 15,
+		allowed: 16,
 		build: func(app *App) {
 			type payload struct {
 				Name  string `json:"name"`
@@ -65,7 +65,7 @@ var allocationBudgets = []allocationBudget{
 	{
 		name:    "not found",
 		target:  "/missing",
-		allowed: 36,
+		allowed: 38,
 		build:   func(app *App) { app.Get("/text", func(call *Call) { call.Text("Hello world") }) },
 	},
 	{


### PR DESCRIPTION
Part 1 of #54: raise the minimum Go version so the validation API refactor in #100 and #101 can use
generic methods.

Generic methods ([golang/go#77273](https://github.com/golang/go/issues/77273)) landed in Go 1.27.0,
which is now GA. The CI matrix drops 1.25 and 1.26 rather than keeping compatibility rows that could
not compile the API that follows.

## The allocation gate moved

`encoding/json.Marshal` allocates twice per call on 1.27 where it allocated once on 1.26, confirmed
in isolation:

```
go1.26: json.Marshal allocs: 1
go1.27: json.Marshal allocs: 2
```

So the two budgets that marshal JSON move with it — `json` 15 → 16, and `not found` 36 → 38 for its
nested error payload. Every budget that does not marshal JSON is unchanged, and no govalin code on
those paths changed. This is the case `perf_test.go` already anticipates: *"escape analysis and
inlining change between releases."*

## Note for anyone working on #100 / #101

The standalone `gofumpt` binary cannot parse generic methods yet — it fails with `method must have
no type parameters` ([mvdan/gofumpt#359](https://github.com/mvdan/gofumpt/issues/359), fix expected
shortly). This does **not** affect CI: `golangci-lint-action` resolves `version: latest`, and
golangci-lint ≥ v2.13.1 built with go1.27 embeds a gofumpt that parses them (verified: clean run and
clean `fmt --diff` against generic-method code). Locally, use `golangci-lint fmt ./...` instead of
`gofumpt -w` on files with generic methods until the fix ships.

## Verification

- `go build ./...`, `go test ./...`, `go test -race ./...` pass on go1.27.0
- `GOVALIN_PERF_GATE=1 go test -run TestAllocationBudget .` passes with the updated budgets
- `golangci-lint run ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
