### PR TITLE
refactor(validation): infer the body type on ValidatedBody

### DIFF
--- a/call.go
+++ b/call.go
@@ -890,11 +890,11 @@ func (call *Call) ValidatedFormParamAsInt(key string) *IntValidator {
 	return validator
 }
 
-// ValidatedBody returns a curryable body validator.
-func (call *Call) ValidatedBody(target interface{}) *BodyValidator {
-	return &BodyValidator{
+// ValidatedBody returns a curryable body validator that unmarshals the request
+// body into target when the chain is closed with Get.
+func (call *Call) ValidatedBody[T any](target *T) *BodyValidator[T] {
+	return &BodyValidator[T]{
 		call:   call,
 		target: target,
-		rules:  make([]func(interface{}) error, 0),
 	}
 }

--- a/validation.go
+++ b/validation.go
@@ -28,15 +28,15 @@ type IntValidator struct {
 }
 
 // BodyValidator provides validation for request body.
-type BodyValidator struct {
+type BodyValidator[T any] struct {
 	call   *Call
-	target interface{}
-	rules  []func(interface{}) error
+	target *T
+	rules  []func(*T) error
 }
 
 // BodyFieldValidator allows chaining validation rules for a specific field.
-type BodyFieldValidator struct {
-	bodyValidator *BodyValidator
+type BodyFieldValidator[T any] struct {
+	bodyValidator *BodyValidator[T]
 	fieldName     string
 }
 
@@ -200,15 +200,11 @@ func (v *IntValidator) Get() (int, error) {
 
 // Body validation methods
 
-// AddRule adds a validation rule to the body validator (implements interface for validation package).
-func (v *BodyValidator) AddRule(rule func(interface{}) error) {
-	v.rules = append(v.rules, rule)
-}
-
-// Custom adds a custom validation rule for the entire body with type safety.
-func (v *BodyValidator) Custom(validatorFn func(interface{}) bool, message string) *BodyValidator {
-	v.rules = append(v.rules, func(data interface{}) error {
-		if !validatorFn(data) {
+// Custom adds a custom validation rule for the entire body. The rule receives
+// the unmarshalled body and attributes a failure to "body".
+func (v *BodyValidator[T]) Custom(validatorFn func(T) bool, message string) *BodyValidator[T] {
+	v.rules = append(v.rules, func(data *T) error {
+		if !validatorFn(*data) {
 			return validation.NewError(validation.NewErrorResponse(
 				http.StatusBadRequest,
 				validation.NewParameterErrorDetail("body", message),
@@ -220,7 +216,7 @@ func (v *BodyValidator) Custom(validatorFn func(interface{}) bool, message strin
 }
 
 // Get validates the body and returns error if invalid.
-func (v *BodyValidator) Get() error {
+func (v *BodyValidator[T]) Get() error {
 	if err := v.call.BodyAs(v.target); err != nil {
 		return err
 	}
@@ -234,16 +230,16 @@ func (v *BodyValidator) Get() error {
 }
 
 // ValidateField sets the current field for validation and returns a BodyFieldValidator.
-func (v *BodyValidator) ValidateField(fieldName string) *BodyFieldValidator {
-	return &BodyFieldValidator{
+func (v *BodyValidator[T]) ValidateField(fieldName string) *BodyFieldValidator[T] {
+	return &BodyFieldValidator[T]{
 		bodyValidator: v,
 		fieldName:     fieldName,
 	}
 }
 
 // Required adds a required validation rule for the current field.
-func (f *BodyFieldValidator) Required() *BodyFieldValidator {
-	f.bodyValidator.rules = append(f.bodyValidator.rules, func(data interface{}) error {
+func (f *BodyFieldValidator[T]) Required() *BodyFieldValidator[T] {
+	f.bodyValidator.rules = append(f.bodyValidator.rules, func(data *T) error {
 		val := reflect.ValueOf(data).Elem()
 		field := val.FieldByName(f.fieldName)
 		if !field.IsValid() {
@@ -265,8 +261,8 @@ func (f *BodyFieldValidator) Required() *BodyFieldValidator {
 }
 
 // MinLength adds a minimum length validation rule for string fields.
-func (f *BodyFieldValidator) MinLength(minimum int) *BodyFieldValidator {
-	f.bodyValidator.rules = append(f.bodyValidator.rules, func(data interface{}) error {
+func (f *BodyFieldValidator[T]) MinLength(minimum int) *BodyFieldValidator[T] {
+	f.bodyValidator.rules = append(f.bodyValidator.rules, func(data *T) error {
 		val := reflect.ValueOf(data).Elem()
 		field := val.FieldByName(f.fieldName)
 		if !field.IsValid() {
@@ -288,8 +284,8 @@ func (f *BodyFieldValidator) MinLength(minimum int) *BodyFieldValidator {
 }
 
 // MaxLength adds a maximum length validation rule for string fields.
-func (f *BodyFieldValidator) MaxLength(maximum int) *BodyFieldValidator {
-	f.bodyValidator.rules = append(f.bodyValidator.rules, func(data interface{}) error {
+func (f *BodyFieldValidator[T]) MaxLength(maximum int) *BodyFieldValidator[T] {
+	f.bodyValidator.rules = append(f.bodyValidator.rules, func(data *T) error {
 		val := reflect.ValueOf(data).Elem()
 		field := val.FieldByName(f.fieldName)
 		if !field.IsValid() {
@@ -311,8 +307,8 @@ func (f *BodyFieldValidator) MaxLength(maximum int) *BodyFieldValidator {
 }
 
 // Email adds an email validation rule for string fields.
-func (f *BodyFieldValidator) Email() *BodyFieldValidator {
-	f.bodyValidator.rules = append(f.bodyValidator.rules, func(data interface{}) error {
+func (f *BodyFieldValidator[T]) Email() *BodyFieldValidator[T] {
+	f.bodyValidator.rules = append(f.bodyValidator.rules, func(data *T) error {
 		val := reflect.ValueOf(data).Elem()
 		field := val.FieldByName(f.fieldName)
 		if !field.IsValid() {
@@ -337,8 +333,8 @@ func (f *BodyFieldValidator) Email() *BodyFieldValidator {
 }
 
 // Min adds a minimum value validation rule for integer fields.
-func (f *BodyFieldValidator) Min(minimum int) *BodyFieldValidator {
-	f.bodyValidator.rules = append(f.bodyValidator.rules, func(data interface{}) error {
+func (f *BodyFieldValidator[T]) Min(minimum int) *BodyFieldValidator[T] {
+	f.bodyValidator.rules = append(f.bodyValidator.rules, func(data *T) error {
 		val := reflect.ValueOf(data).Elem()
 		field := val.FieldByName(f.fieldName)
 		if !field.IsValid() {
@@ -360,8 +356,8 @@ func (f *BodyFieldValidator) Min(minimum int) *BodyFieldValidator {
 }
 
 // Max adds a maximum value validation rule for integer fields.
-func (f *BodyFieldValidator) Max(maximum int) *BodyFieldValidator {
-	f.bodyValidator.rules = append(f.bodyValidator.rules, func(data interface{}) error {
+func (f *BodyFieldValidator[T]) Max(maximum int) *BodyFieldValidator[T] {
+	f.bodyValidator.rules = append(f.bodyValidator.rules, func(data *T) error {
 		val := reflect.ValueOf(data).Elem()
 		field := val.FieldByName(f.fieldName)
 		if !field.IsValid() {
@@ -382,9 +378,10 @@ func (f *BodyFieldValidator) Max(maximum int) *BodyFieldValidator {
 	return f
 }
 
-// Custom adds a custom validation rule for the current field.
-func (f *BodyFieldValidator) Custom(validatorFn func(interface{}) bool, message string) *BodyFieldValidator {
-	f.bodyValidator.rules = append(f.bodyValidator.rules, func(data interface{}) error {
+// Custom adds a custom validation rule that attributes its failure to the current
+// field. The rule receives a pointer to the whole body, not the field value.
+func (f *BodyFieldValidator[T]) Custom(validatorFn func(interface{}) bool, message string) *BodyFieldValidator[T] {
+	f.bodyValidator.rules = append(f.bodyValidator.rules, func(data *T) error {
 		if !validatorFn(data) {
 			return validation.NewError(validation.NewErrorResponse(
 				http.StatusBadRequest,
@@ -397,6 +394,6 @@ func (f *BodyFieldValidator) Custom(validatorFn func(interface{}) bool, message 
 }
 
 // Get completes the field validation and returns the body validator for more fields or final validation.
-func (f *BodyFieldValidator) Get() *BodyValidator {
+func (f *BodyFieldValidator[T]) Get() *BodyValidator[T] {
 	return f.bodyValidator
 }

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -3,8 +3,6 @@
 package validation
 
 import (
-	"net/http"
-
 	"github.com/pkkummermo/govalin/internal/validation"
 )
 
@@ -78,86 +76,4 @@ func Validate[T any]() *validation.Validator[T] {
 // Custom creates a custom validation rule for any type T - use with caution.
 func Custom[T any](fn func(T) bool, message string) validation.Rule[T] {
 	return validation.Custom(fn, message)
-}
-
-// TypedValidator provides a curryable typed validator.
-type TypedValidator[T any] struct {
-	validator interface {
-		AddRule(func(interface{}) error)
-		Get() error
-	}
-	rules []func(T) (bool, string)
-}
-
-// WithTyped creates a curryable typed validator for type-safe custom validation.
-func WithTyped[T any, V interface {
-	AddRule(func(interface{}) error)
-	Get() error
-}](v V) *TypedValidator[T] {
-	return &TypedValidator[T]{
-		validator: v,
-		rules:     make([]func(T) (bool, string), 0),
-	}
-}
-
-// Custom adds a type-safe custom validation rule that can be chained.
-func (tv *TypedValidator[T]) Custom(validatorFn func(T) bool, message string) *TypedValidator[T] {
-	tv.rules = append(tv.rules, func(data T) (bool, string) {
-		return validatorFn(data), message
-	})
-	return tv
-}
-
-// Get executes all validation rules and returns any validation error.
-func (tv *TypedValidator[T]) Get() error {
-	// Add all accumulated rules to the underlying validator
-	for _, rule := range tv.rules {
-		validatorFn := rule // Capture the rule in closure
-		tv.validator.AddRule(func(data interface{}) error {
-			typedData, ok := data.(*T)
-			if !ok {
-				return validation.NewError(validation.NewErrorResponse(
-					http.StatusBadRequest,
-					validation.NewParameterErrorDetail("body", "Type assertion failed"),
-				))
-			}
-			if valid, message := validatorFn(*typedData); !valid {
-				return validation.NewError(validation.NewErrorResponse(
-					http.StatusBadRequest,
-					validation.NewParameterErrorDetail("body", message),
-				))
-			}
-			return nil
-		})
-	}
-
-	// Execute the underlying validator
-	return tv.validator.Get()
-}
-
-// WithTypedCustom adds a type-safe custom validation rule for the entire body using a helper function
-// This function works with any type that has an AddRule method
-// Deprecated: Use WithTyped().Custom(...).Get() for curryable validation.
-func WithTypedCustom[T any, V interface{ AddRule(func(interface{}) error) }](
-	v V,
-	validatorFn func(T) bool,
-	message string,
-) V {
-	v.AddRule(func(data interface{}) error {
-		typedData, ok := data.(*T)
-		if !ok {
-			return validation.NewError(validation.NewErrorResponse(
-				http.StatusBadRequest,
-				validation.NewParameterErrorDetail("body", "Type assertion failed"),
-			))
-		}
-		if !validatorFn(*typedData) {
-			return validation.NewError(validation.NewErrorResponse(
-				http.StatusBadRequest,
-				validation.NewParameterErrorDetail("body", message),
-			))
-		}
-		return nil
-	})
-	return v
 }

--- a/validation_test.go
+++ b/validation_test.go
@@ -219,7 +219,6 @@ func TestValidatedBody(t *testing.T) {
 	app.Post("/validate-body", func(call *govalin.Call) {
 		var user TestUser
 
-		// Use generic validation methods on ValidatedBody - no validation package import needed!
 		err := call.ValidatedBody(&user).
 			ValidateField("Name").Required().MinLength(2).Get().
 			ValidateField("Email").Required().Email().Get().
@@ -404,14 +403,10 @@ func TestBodyValidatorCustom(t *testing.T) {
 	app.Post("/validate-body-custom-validator", func(call *govalin.Call) {
 		var user TestUser
 
-		// Use validation.WithTypedCustom for type-safe validation without manual type casting
-		validator := call.ValidatedBody(&user)
-		validator = validation.WithTypedCustom(validator, func(user TestUser) bool {
-			// Type-safe custom validation on the entire body - no casting needed!
-			return user.Name != "InvalidUser" && user.Age >= 18
-		}, "User validation failed: invalid user or under 18")
-
-		err := validator.
+		err := call.ValidatedBody(&user).
+			Custom(func(user TestUser) bool {
+				return user.Name != "InvalidUser" && user.Age >= 18
+			}, "User validation failed: invalid user or under 18").
 			ValidateField("Name").Required().MinLength(2).Get().
 			ValidateField("Email").Required().Email().Get().
 			Get()
@@ -444,27 +439,22 @@ func TestBodyValidatorCustom(t *testing.T) {
 	})
 }
 
-func TestBodyValidatorWithTypedCustom(t *testing.T) {
+func TestBodyValidatorCustomChained(t *testing.T) {
 	app := newTestApp()
 	app.Post("/validate-typed-custom", func(call *govalin.Call) {
 		var user TestUser
 
-		// Use validation.WithTyped for curryable type-safe validation without manual type casting
-		err := validation.WithTyped[TestUser](call.ValidatedBody(&user)).
+		err := call.ValidatedBody(&user).
 			Custom(func(user TestUser) bool {
-				// Type-safe custom validation - no casting needed!
-				// Test complex business rule: name must not contain "banned"
 				return user.Name != "banned"
 			}, "Name cannot be 'banned'").
 			Custom(func(user TestUser) bool {
-				// Chain another validation: email domain rules
 				if user.Email == "admin@test.com" && user.Age < 21 {
-					return false // Admin emails require age 21+
+					return false
 				}
 				return true
 			}, "Admin emails require age 21 or higher").
 			Custom(func(user TestUser) bool {
-				// Chain another validation: general minimum age requirement
 				return user.Age >= 13
 			}, "Must be at least 13 years old").
 			Get()
@@ -509,13 +499,12 @@ func TestBodyValidatorWithTypedCustom(t *testing.T) {
 	})
 }
 
-func TestCurryableTypedCustomValidation(t *testing.T) {
+func TestCurryableCustomBodyValidation(t *testing.T) {
 	app := newTestApp()
 	app.Post("/validate-curryable-typed", func(call *govalin.Call) {
 		var user TestUser
 
-		// Demonstrate the curryable API: WithTyped().Custom(...).Custom(...).Custom(...).Get()
-		err := validation.WithTyped[TestUser](call.ValidatedBody(&user)).
+		err := call.ValidatedBody(&user).
 			Custom(func(u TestUser) bool {
 				return len(u.Name) >= 2
 			}, "Name must be at least 2 characters").


### PR DESCRIPTION
Closes #100. Part 2 of #54.

**Stacked on #102** — based on `feat/54-go127-toolchain`, since it needs the Go 1.27 bump to
compile. GitHub will retarget this to `main` once #102 merges; review it after that one.

## What changes

`ValidatedBody` becomes a generic method, so the body type is inferred from the argument instead of
being threaded in from outside the chain:

```go
func (call *Call) ValidatedBody[T any](target *T) *BodyValidator[T]
```

```go
// before
err := validation.WithTyped[TestUser](call.ValidatedBody(&user)).
    Custom(func(u TestUser) bool { return len(u.Name) >= 2 }, "...").
    Get()

// after
err := call.ValidatedBody(&user).
    Custom(func(u TestUser) bool { return len(u.Name) >= 2 }, "...").
    Get()
```

`Call` is not a generic type, which is why this needed generic methods
([golang/go#77273](https://github.com/golang/go/issues/77273)) rather than being possible all along.

## What it deletes

140 lines removed against 42 added. `WithTyped`, `WithTypedCustom` and `TypedValidator` go from
`validation/validation.go`, along with `BodyValidator.AddRule` and the
`interface{ AddRule(...); Get() error }` indirection that only existed to reach across the import
boundary. The runtime type assertion those needed goes with them — `*T` makes the same mistake a
compile error.

Note this drops the `.Typed[T]()` method that #54 originally specified. It was itself a workaround
for `ValidatedBody` not being generic, so making `ValidatedBody` generic removes the need for it
rather than reimplementing it — see the [comment on
#54](https://github.com/pkkummermo/govalin/issues/54#issuecomment-5381326800).

## Not in scope

`BodyFieldValidator` is carried over as `BodyFieldValidator[T]` and still resolves fields through
`reflect.FieldByName`. #101 deletes that path wholesale; it is deliberately untouched here.

## Verification

On go1.27.0: `go build ./...`, `go test ./...`, `go test -race ./...`,
`GOVALIN_PERF_GATE=1 go test -run TestAllocationBudget .` all pass, and `golangci-lint run ./...` is
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
